### PR TITLE
page2svg-img: preserve <span> tag

### DIFF
--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -381,18 +381,18 @@ function GetSpeech() {
 function GetIMG() {
   var n = 0, nodes = document.getElementsByClassName("MathJax_SVG");
   for (var i = nodes.length-1; i >= 0; i--) {
-    var svg = nodes[i].getElementsByTagName("svg")[0];
+    var svg = nodes[i].querySelector("svg");
     var css = svg.style.cssText + 
          " width:"+svg.getAttribute("width") + "; height:"+svg.getAttribute("height");
     svg.style.cssText = ""; // this will be handled by the <img> tag instead
     svg.setAttribute("xmlns","http://www.w3.org/2000/svg");
-    svg = svg.outerHTML.replace(/><([^/])/g,">\n<$1").replace(/(<\/[a-z]*>)(?=<\/)/g,"$1\n");
-    svg = new Buffer(svg).toString("base64");  // encode svg as base64
+    var svgData = svg.outerHTML.replace(/><([^/])/g,">\n<$1").replace(/(<\/[a-z]*>)(?=<\/)/g,"$1\n");
+    svgData = new Buffer(svgData).toString("base64");  // encode svg as base64
     var img = MathJax.HTML.Element("img",{
-      src:"data:image/svg+xml;base64,"+svg, style:{cssText:css},
+      src:"data:image/svg+xml;base64,"+svgData, style:{cssText:css},
       className: "MathJax_SVG_IMG"
     });
-    nodes[i].parentNode.replaceChild(img,nodes[i]);
+    svg.parentNode.replaceChild(img, svg);
   }
 }
 


### PR DESCRIPTION
Instead of replacing svg element with img element, page2svg-img
replaces the span parent of the svg element. This results in the
suppresion of the span element.

This span element is important in certain situations (zooming for
example) ; we have to keep it and replace only the svg element.

Fixes mathjax/MathJax-node#18
