### PR TITLE
Fix PNG rendering outside of root directory.

### DIFF
--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -28,7 +28,9 @@
 
 var http = require('http');
 var fs = require('fs');
-var dirname = require('path').dirname;
+var path = require('path'),
+    dirname = path.dirname;
+var fmt = require('util').format;
 var jsdom = require('jsdom').jsdom;
 var exec = require('child_process').exec;
 var speech = require('speech-rule-engine');
@@ -61,6 +63,9 @@ var defaults = {
 };
 
 var MathJaxPath = "file://"+dirname(dirname(require.resolve("./mj-single.js")))+"/mathjax/unpacked";
+var BatikRasterizerPath = path.resolve(__dirname,
+                                       '..',
+                                       'batik/batik-rasterizer.jar');
 var MathJaxConfig;         // configuration for when starting MathJax
 var MathJax;   // filled in once MathJax is loaded
 var serverStarted = false; // true when the MathJax DOM has been created
@@ -400,7 +405,11 @@ function GetSVG(result) {
   if (data.png) {
     var callback = MathJax.Callback(function () {}); // for synchronization with MathJax
     fs.writeFileSync(tmpfile+".svg",svgfile);
-    exec("java -jar batik/batik-rasterizer.jar -dpi "+data.dpi+" "+tmpfile+".svg",function (err,stdout,stderr) {
+    var batikCommand = fmt('java -jar %s -dpi %d %s.svg',
+                           BatikRasterizerPath,
+                           data.dpi,
+                           tmpfile);
+    exec(batikCommand, function (err,stdout,stderr) {
       if (err) {AddError(err)} else {
         var buffer = fs.readFileSync(tmpfile+".png");
         result.png = "data:image/png;base64," + buffer.toString('base64');


### PR DESCRIPTION
This commit references the `batik-rasterization.jar` file by its full
path, calculated based on the root MathJax-node directory's location.
This allows users to call the library from any directory and render
`.png` files as expected.
