### PR TITLE
fix jsdom version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "url": "git://github.com/mathjax/MathJax-node.git"
     },
     "dependencies": {
-       "jsdom": "*",
+       "jsdom": "1.0.2",
        "speech-rule-engine": "*",
        "yargs": "*"
     },


### PR DESCRIPTION
Fixing the version was  suggestion from the jsdom devs a while back. Since more recent jsdom versions seem to cause trouble, I think we might want to fix this to a working version for now. Ideally, `~1.0.2`,  `^1.0.2` or `1.0.x` could be switched to eventually.
