### PR TITLE
improving speech-rule-engine integration

### DIFF
--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -355,6 +355,14 @@ function GetMML(result) {
     if (!err.restart) {throw err;} // an actual error
     return MathJax.Callback.After(window.Array(GetMML,result),err.restart);
   }
+  if (data.speakText) {
+      speech.setupEngine({semantics: true, domain: data.speakRuleset, style: data.speakStyle});
+    result.speakText = speech.processExpression(result.mml);
+//TODO replace regex hack with proper approach of augmenting the internal format
+//    jax.root.alt = result.speakText;
+//    jax.root.attrNames.push("alt");
+    result.mml = result.mml.replace(/<math/g,'<math alt="'+result.speakText+'"');
+  }
 }
 
 //
@@ -367,13 +375,23 @@ function GetSVG(result) {
       svg = script.previousSibling.getElementsByTagName("svg")[0];
   svg.setAttribute("xmlns","http://www.w3.org/2000/svg");
 
-  //
-  //  Add the speech elements, if needed
-  //
+
+//
+//  Add the speech text and mark the SVG appropriately
+//
   if (data.speakText) {
-    GetSpeech(svg,result.mml);
-    if (!data.mml) {delete result.mml}
-  }
+    ID++; var id = "MathJax-SVG-"+ID;
+    var speak = result.speakText;
+    svg.setAttribute("role","math");
+    svg.setAttribute("aria-labelledby",id+"-Title "+id+"-Desc");
+    for (var i=0, m=svg.childNodes.length; i < m; i++)
+      {svg.childNodes[i].setAttribute("aria-hidden",true);}
+    var node = MathJax.HTML.Element("desc",{id:id+"-Desc"},[speak]);
+    svg.insertBefore(node,svg.firstChild);
+    node = MathJax.HTML.Element("title",{id:id+"-Title"},["Equation"]);
+    svg.insertBefore(node,svg.firstChild);
+    if (!data.mml) {delete result.mml;}
+   }
 
   //
   //  SVG data is modified to add linebreaks for readability,
@@ -414,23 +432,6 @@ function GetSVG(result) {
     });
     return callback;  //  This keeps the queue from continuing until the exec() is complete
   }
-}
-
-//
-//  Add the speech text and mark the SVG appropriately
-//
-function GetSpeech(svg,mml) {
-  ID++; var id = "MathJax-SVG-"+ID;
-  speech.setupEngine({semantics: true, domain: data.speakRuleset, style: data.speakStyle});
-  var speak = speech.processExpression(mml);
-  svg.setAttribute("role","math");
-  svg.setAttribute("aria-labelledby",id+"-Title "+id+"-Desc");
-  for (var i=0, m=svg.childNodes.length; i < m; i++)
-    {svg.childNodes[i].setAttribute("aria-hidden",true)}
-  var node = MathJax.HTML.Element("desc",{id:id+"-Desc"},[speak]);
-  svg.insertBefore(node,svg.firstChild);
-  node = MathJax.HTML.Element("title",{id:id+"-Title"},["Equation"]);
-  svg.insertBefore(node,svg.firstChild);
 }
 
 //


### PR DESCRIPTION
This fixes #49 and #50.
- the `result` will now have a separate `speakText` (not sure about the name)
- the MathML will now have the speech string in the alt-text (See inline comments -- I couldn't make the proper way work; for now a regex will have to do.)
