### PR TITLE
Add onInitComplete hook to configuration

### DIFF
--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -36,6 +36,7 @@ var speech = require('speech-rule-engine');
 var displayMessages = false;      // don't log Message.Set() calls
 var displayErrors = true;         // show error messages on the console
 var undefinedChar = false;        // unknown characters are not saved in the error array
+var onInitComplete = null;        // to be called, if present, at the end of AuthorInit.
 
 var defaults = {
   ex: 6,                          // ex-size in pixels
@@ -331,6 +332,8 @@ function ConfigureMathJax() {
         MathJax.Hub.Queue(StartQueue);
       });
 
+    
+      if(typeof onInitComplete === 'function') { onInitComplete(MathJax); }
     }
   };
 
@@ -795,5 +798,6 @@ exports.config = function (config) {
   if (config.displayMessages != null)    {displayMessages = config.displayMessages}
   if (config.displayErrors != null)      {displayErrors   = config.displayErrors}
   if (config.undefinedCharError != null) {undefinedChar   = config.undefinedCharError}
+  if (config.onInitComplete != null)     {onInitComplete  = config.onInitComplete}
   if (config.MathJax) {MathJaxConfig = config.MathJax}
 }


### PR DESCRIPTION
This PR just adds an initialization callback, allowing client code authors to then run arbitrary mathjax config code after the MathJax object is fully setup but before it queues anything.

See https://github.com/mathjax/MathJax-node/issues/54 for an example use case.
