### PR TITLE
Changed mj-single.js and tex2* to allow invalid TeX command

### DIFF
--- a/bin/tex2mml
+++ b/bin/tex2mml
@@ -51,6 +51,10 @@ var argv = require("yargs")
     notexhints: {
       boolean: true,
       describe: "don't add TeX-specific classes"
+    },
+    allowinvalid: {
+      boolean: true,
+      describe: "do not fail for invalid TeX commands (display red)"
     }
   })
   .argv;
@@ -61,7 +65,8 @@ mjAPI.config({
       semantics: argv.semantics,
       texHints: !argv.notexhints
     }
-  }
+  },
+  allowInvalidTeX: argv.allowinvalid
 });
 mjAPI.start();
 

--- a/bin/tex2png
+++ b/bin/tex2png
@@ -52,12 +52,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    allowinvalid: {
+      boolean: true,
+      describe: "do not fail for invalid TeX commands (display red)"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, allowInvalidTeX: argv.allowinvalid});
 mjAPI.start();
 
 mjAPI.typeset({

--- a/bin/tex2svg
+++ b/bin/tex2svg
@@ -59,12 +59,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    allowinvalid: {
+      boolean: true,
+      describe: "do not fail for invalid TeX commands (display red)"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, allowInvalidTeX: argv.allowinvalid});
 mjAPI.start();
 
 mjAPI.typeset({

--- a/bin/tex2svg-filter
+++ b/bin/tex2svg-filter
@@ -63,12 +63,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    allowinvalid: {
+      boolean: true,
+      describe: "do not fail for invalid TeX commands (display red)"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, allowInvalidTeX: argv.allowinvalid});
 mjAPI.start();
 
 var prefix = argv._[0];  // the file prefix

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -37,6 +37,7 @@ var speech = require('speech-rule-engine');
 var displayMessages = false;      // don't log Message.Set() calls
 var displayErrors = true;         // show error messages on the console
 var undefinedChar = false;        // unknown characters are not saved in the error array
+var allowInvalidTeX = false;      // invalid TeX commands cause failure
 
 var defaults = {
   ex: 6,                          // ex-size in pixels
@@ -308,6 +309,7 @@ function ConfigureMathJax() {
     }
   };
 
+  if (allowInvalidTeX) { window.MathJax.TeX.extensions.push("noUndefined.js"); }
   if (MathJaxConfig) {Insert(window.MathJax,MathJaxConfig)}
 }
 
@@ -664,5 +666,6 @@ exports.config = function (config) {
   if (config.displayMessages != null)    {displayMessages = config.displayMessages}
   if (config.displayErrors != null)      {displayErrors   = config.displayErrors}
   if (config.undefinedCharError != null) {undefinedChar   = config.undefinedCharError}
+  if (config.allowInvalidTeX != null)    {allowInvalidTeX = config.allowInvalidTeX}
   if (config.MathJax) {MathJaxConfig = config.MathJax}
 }


### PR DESCRIPTION
Before this change, use of an unsupported TeX command e.g. \frog
causes an error. This change adds an option (default false) to
permit invalid commands by using the noUndefined.js MathJax
extension. This results in the command being displayed as literal
text, in red, in the resulting SVG output.

I added --allowinvalid command-line flag to the tex2* utilities
to use the new feature.