### PR TITLE
Use OS temp directory os.tmpdir() rather than hard-coded /tmp

### DIFF
--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -32,6 +32,7 @@ var fmt = require('util').format;
 var jsdom = require("jsdom").jsdom;
 var exec = require('child_process').exec;
 var speech = require('speech-rule-engine');
+var os = require('os');
 
 var displayMessages = false;      // don't log Message.Set() calls
 var displayErrors = true;         // show error messages on the console
@@ -81,7 +82,7 @@ var MathJax;                       // filled in once MathJax is loaded
 var serverState = STATE.STOPPED;   // nothing loaded yet
 var timer;                         // used to reset MathJax if it runs too long
 
-var tmpfile = "/tmp/mj-single-svg";  // file name prefix to use for temp files
+var tmpfile = os.tmpdir() + "/mj-single-svg";  // file name prefix to use for temp files
 
 var document, window, content, html; // the DOM elements
 

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -33,6 +33,7 @@ var fmt = require('util').format;
 var jsdom = require('jsdom').jsdom;
 var exec = require('child_process').exec;
 var speech = require('speech-rule-engine');
+var os = require('os');
 
 var displayMessages = false;      // don't log Message.Set() calls
 var displayErrors = true;         // show error messages on the console
@@ -79,7 +80,7 @@ var MathJaxConfig;                   // configuration for when starting MathJax
 var MathJax;                         // filled in once MathJax is loaded
 var serverState = STATE.STOPPED;     // nothing loaded yet
 var timer;                           // used to reset MathJax if it runs too long
-var tmpfile = "/tmp/mj-single-svg";  // file name prefix to use for temp files
+var tmpfile = os.tmpdir() + "/mj-single-svg";  // file name prefix to use for temp files
 
 var document, window, content, html; // the DOM elements
 


### PR DESCRIPTION
This makes it easier to use on operating systems (Windows) where /tmp
normally does not exist (and is probably the right thing to do anyhow).