### PR TITLE
Changed Batik calls to use execFile instead of exec

### DIFF
--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -30,7 +30,7 @@ var fs = require('fs');
 var path = require('path');
 var fmt = require('util').format;
 var jsdom = require("jsdom").jsdom;
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var speech = require('speech-rule-engine');
 
 var displayMessages = false;      // don't log Message.Set() calls
@@ -659,7 +659,7 @@ function MakeIMG() {
 function MakePNG() {
   if (data.renderer === "PNG") {
     var synch = MathJax.Callback(function () {});  // for synchronization with MathJax
-    var batikCommand = fmt("java -jar %s -dpi %d '%s.svg'",BatikRasterizerPath,data.dpi,tmpfile);
+    var batikCommands = ['-jar', BatikRasterizerPath, '-dpi', data.dpi, tmpfile + '.svg'];
     var tmpSVG = tmpfile+".svg", tmpPNG = tmpfile+".png";
     var nodes = document.getElementsByClassName("MathJax_SVG");
     var check = function (err) {if (err) {AddError(err.message); return true}}
@@ -677,7 +677,7 @@ function MakePNG() {
       ].join("\n");
       fs.writeFile(tmpSVG,svg,function (err) {
         if (check(err)) return PNG(i-1);
-        exec(batikCommand, function (err,stdout,stderr) {
+        execFile('java', batikCommands, function (err,stdout,stderr) {
           if (check(err)) {fs.unlinkSync(tmpSVG); return PNG(i-1)}
           fs.readFile(tmpPNG,null,function (err,buffer) {
             if (!check(err)) {

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -31,7 +31,7 @@ var fs = require('fs');
 var path = require('path');
 var fmt = require('util').format;
 var jsdom = require('jsdom').jsdom;
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var speech = require('speech-rule-engine');
 
 var displayMessages = false;      // don't log Message.Set() calls
@@ -456,13 +456,13 @@ function GetSVG(result) {
 function GetPNG(result) {
   var svgfile = result.svgfile; delete result.svgfile;
   if (data.png) {
-    var batikCommand = fmt("java -jar %s -dpi %d '%s.svg'",BatikRasterizerPath,data.dpi,tmpfile);
+    var batikCommands = ['-jar', BatikRasterizerPath, '-dpi', data.dpi, tmpfile + '.svg'];
     var synch = MathJax.Callback(function () {}); // for synchronization with MathJax
     var check = function (err) {if (err) {AddError(err.message); synch(); return true}}
     var tmpSVG = tmpfile+".svg", tmpPNG = tmpfile+".png";
     fs.writeFile(tmpSVG,svgfile,function (err) {
       if (check(err)) return;
-      exec(batikCommand, function (err,stdout,stderr) {
+      execFile('java', batikCommands, function (err,stdout,stderr) {
         if (check(err)) {fs.unlinkSync(tmpSVG); return}
         fs.readFile(tmpPNG,null,function (err,buffer) {
           result.png = "data:image/png;base64,"+(buffer||"").toString('base64');


### PR DESCRIPTION
In addition to being more secure, execFile (with arguments as an array)
should work on all platforms because it does not require a hardcoded
quote character. (On windows, quoting with the single ' causes this
call to fail.)