### PR TITLE
Allow extensions to be specified on command line

### DIFF
--- a/bin/am2mml
+++ b/bin/am2mml
@@ -43,6 +43,10 @@ var argv = require("yargs")
     semantics: {
       boolean: true,
       describe: "add AsciiMath code in <semantics> tag"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
@@ -52,7 +56,8 @@ mjAPI.config({
     menuSettings: {
       semantics: argv.semantics
     }
-  }
+  },
+  extensions: argv.extensions
 });
 mjAPI.start();
 

--- a/bin/am2png
+++ b/bin/am2png
@@ -48,12 +48,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 if (argv.dpi === 0) {argv.dpi = argv.ex * 16} // pixels properly sized

--- a/bin/am2svg
+++ b/bin/am2svg
@@ -55,12 +55,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 mjAPI.typeset({

--- a/bin/mml2mml
+++ b/bin/mml2mml
@@ -40,11 +40,15 @@ var argv = require("yargs")
     speechstyle: {
       default: "default",
       describe: "style to use for speech text (default, brief, sbrief)"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
-mjAPI.config({});
+mjAPI.config({extensions: argv.extensions});
 mjAPI.start();
 
 mjAPI.typeset({

--- a/bin/mml2png
+++ b/bin/mml2png
@@ -47,12 +47,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 if (argv.dpi === 0) {argv.dpi = argv.ex * 16} // pixels properly sized

--- a/bin/mml2svg
+++ b/bin/mml2svg
@@ -55,12 +55,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 mjAPI.typeset({

--- a/bin/mml2svg-html5
+++ b/bin/mml2svg-html5
@@ -63,12 +63,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 //

--- a/bin/page2mml
+++ b/bin/page2mml
@@ -71,13 +71,17 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 argv.format = argv.format.split(/ *, */);
 
-mjAPI.config({MathJax: {menuSettings: {semantics: argv.semantics}}});
+mjAPI.config({MathJax: {menuSettings: {semantics: argv.semantics}}, extensions: argv.extensions});
 mjAPI.start();
 
 //

--- a/bin/page2png
+++ b/bin/page2png
@@ -83,13 +83,17 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 argv.format = argv.format.split(/ *, */);
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 if (argv.dpi === 0) {argv.dpi = argv.ex * 16} // pixels properly sized

--- a/bin/page2svg
+++ b/bin/page2svg
@@ -87,13 +87,17 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 argv.format = argv.format.split(/ *, */);
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 //

--- a/bin/tex2mml
+++ b/bin/tex2mml
@@ -51,6 +51,10 @@ var argv = require("yargs")
     notexhints: {
       boolean: true,
       describe: "don't add TeX-specific classes"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
@@ -61,7 +65,8 @@ mjAPI.config({
       semantics: argv.semantics,
       texHints: !argv.notexhints
     }
-  }
+  },
+  extensions: argv.extensions
 });
 mjAPI.start();
 

--- a/bin/tex2png
+++ b/bin/tex2png
@@ -52,12 +52,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 if (argv.dpi === 0) {argv.dpi = argv.ex * 16} // pixels properly sized

--- a/bin/tex2svg
+++ b/bin/tex2svg
@@ -59,12 +59,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 mjAPI.typeset({

--- a/bin/tex2svg-filter
+++ b/bin/tex2svg-filter
@@ -63,12 +63,16 @@ var argv = require("yargs")
     width: {
       default: 100,
       describe: "width of container in ex"
+    },
+    extensions: {
+      default: "",
+      describe: "extra MathJax extensions e.g. 'Safe,TeX/noUndefined'"
     }
   })
   .argv;
 
 if (argv.font === "STIX") argv.font = "STIX-Web";
-mjAPI.config({MathJax: {SVG: {font: argv.font}}});
+mjAPI.config({MathJax: {SVG: {font: argv.font}}, extensions: argv.extensions});
 mjAPI.start();
 
 var prefix = argv._[0];  // the file prefix

--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -36,6 +36,7 @@ var speech = require('speech-rule-engine');
 var displayMessages = false;      // don't log Message.Set() calls
 var displayErrors = true;         // show error messages on the console
 var undefinedChar = false;        // unknown characters are not saved in the error array
+var extensions = '';              // no additional extensions used
 
 var defaults = {
   ex: 6,                          // ex-size in pixels
@@ -341,6 +342,16 @@ function ConfigureMathJax() {
     }
   };
 
+  if (extensions) {
+    //
+    // Parse added extensions list and add to standard ones
+    //
+    var extensionList = extensions.split(/s*,\s*/);
+    for (var i = 0; i < extensionList.length; i++) {
+      var matches = extensionList[i].match(/^(.*?)(\.js)?$/);
+      window.MathJax.extensions.push(matches[1] + '.js');
+    }
+  }
   if (MathJaxConfig) {Insert(window.MathJax,MathJaxConfig)}
 }
 
@@ -797,17 +808,20 @@ exports.start = function () {RestartMathJax()}
 //  Configure MathJax and the API
 //  You can pass additional configuration options to MathJax using the
 //    MathJax property, and can set displayErrors and displayMessages
-//    that control the display of error messages
+//    that control the display of error messages, and extensions to add
+//    additional MathJax extensions to the base or to sub-categories.
 //
 //  E.g.
-//     mjAPI.congif({
+//     mjAPI.config({
 //       MathJax: {SVG: {font: "STIX-Web"}},
 //       displayErrors: false
+//       extensions: 'Safe,TeX/noUndefined'
 //     });
 //
 exports.config = function (config) {
   if (config.displayMessages != null)    {displayMessages = config.displayMessages}
   if (config.displayErrors != null)      {displayErrors   = config.displayErrors}
   if (config.undefinedCharError != null) {undefinedChar   = config.undefinedCharError}
+  if (config.extensions != null)         {extensions      = config.extensions}
   if (config.MathJax) {MathJaxConfig = config.MathJax}
 }

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -37,6 +37,7 @@ var speech = require('speech-rule-engine');
 var displayMessages = false;      // don't log Message.Set() calls
 var displayErrors = true;         // show error messages on the console
 var undefinedChar = false;        // unknown characters are not saved in the error array
+var extensions = '';              // no additional extensions used
 
 var defaults = {
   ex: 6,                          // ex-size in pixels
@@ -315,6 +316,16 @@ function ConfigureMathJax() {
     }
   };
 
+  if (extensions) {
+    //
+    // Parse added extensions list and add to standard ones
+    //
+    var extensionList = extensions.split(/s*,\s*/);
+    for (var i = 0; i < extensionList.length; i++) {
+      var matches = extensionList[i].match(/^(.*?)(\.js)?$/);
+      window.MathJax.extensions.push(matches[1] + '.js');
+    }
+  }
   if (MathJaxConfig) {Insert(window.MathJax,MathJaxConfig)}
 }
 
@@ -660,17 +671,20 @@ exports.start = function () {RestartMathJax()}
 //  Configure MathJax and the API
 //  You can pass additional configuration options to MathJax using the
 //    MathJax property, and can set displayErrors and displayMessages
-//    that control the display of error messages
+//    that control the display of error messages, and extensions to add
+//    additional MathJax extensions to the base or to sub-categories.
 //
 //  E.g.
-//     mjAPI.congif({
+//     mjAPI.config({
 //       MathJax: {SVG: {font: "STIX-Web"}},
-//       displayErrors: false
+//       displayErrors: false,
+//       extensions: 'Safe,TeX/noUndefined'
 //     });
 //
 exports.config = function (config) {
   if (config.displayMessages != null)    {displayMessages = config.displayMessages}
   if (config.displayErrors != null)      {displayErrors   = config.displayErrors}
   if (config.undefinedCharError != null) {undefinedChar   = config.undefinedCharError}
+  if (config.extensions != null)         {extensions      = config.extensions}
   if (config.MathJax) {MathJaxConfig = config.MathJax}
 }


### PR DESCRIPTION
Adds an 'extensions' option to config which takes a comma-separated
list of extensions to add to the default set. Then adds --extensions
parameter to each command-line tool to specify this value.

This allows use of MathJax features such as displaying invalid TeX
instead of failing to render (--extensions TeX/noUndefined), and
stripping out dangerous links from MathML (--extensions Safe).