### PR TITLE
update jsdom for iojs / nodejs v4 compatibility

### DIFF
--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -116,7 +116,7 @@ var STYLES;           // filled in when SVG is loaded
 function GetWindow() {
   document = jsdom();
   html = document.firstChild;
-  window = document.parentWindow;
+  window = document.defaultView;
   window.console = console;
   window.onerror = function (err,url,line) {AddError("Error: "+err)}
   content = document.body.appendChild(document.createElement("div"));

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -117,7 +117,7 @@ var delimiters = {
 function GetWindow() {
   document = jsdom();
   html = document.firstChild;
-  window = document.parentWindow;
+  window = document.defaultView;
   window.console = console;
   window.onerror = function (err,url,line) {AddError("Error: "+err)}
   content = document.body.appendChild(document.createElement("div"));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "url": "git://github.com/mathjax/MathJax-node.git"
     },
     "dependencies": {
-        "jsdom": "3.1.1",
+        "jsdom": "*",
         "speech-rule-engine": "*",
         "yargs": "*",
         "MathJax": "https://github.com/mathjax/MathJax/tarball/mathjax-node-2.5.1"


### PR DESCRIPTION
Updates jsdom to enable upcoming node+iojs merge (v4). 

:warning:  This drops compatibility for older nodejs versions.

Closes #110.