### PR TITLE
adding random number to hard coded filename to allow concurrency

### DIFF
--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -87,7 +87,7 @@ var MathJax;                       // filled in once MathJax is loaded
 var serverState = STATE.STOPPED;   // nothing loaded yet
 var timer;                         // used to reset MathJax if it runs too long
 
-var tmpfile = os.tmpdir() + "/mj-single-svg";  // file name prefix to use for temp files
+var tmpfile = os.tmpdir() + "/mj-single-svg" +  process.pid;  // file name prefix to use for temp files
 
 var document, window, content, html; // the DOM elements
 

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -85,7 +85,7 @@ var MathJaxConfig;                   // configuration for when starting MathJax
 var MathJax;                         // filled in once MathJax is loaded
 var serverState = STATE.STOPPED;     // nothing loaded yet
 var timer;                           // used to reset MathJax if it runs too long
-var tmpfile = os.tmpdir() + "/mj-single-svg" +  Math.floor(Math.random() * 1000);  // file name prefix to use for temp files
+var tmpfile = os.tmpdir() + "/mj-single-svg" +  process.pid;  // file name prefix to use for temp files
 
 var document, window, content, html; // the DOM elements
 

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -85,7 +85,7 @@ var MathJaxConfig;                   // configuration for when starting MathJax
 var MathJax;                         // filled in once MathJax is loaded
 var serverState = STATE.STOPPED;     // nothing loaded yet
 var timer;                           // used to reset MathJax if it runs too long
-var tmpfile = os.tmpdir() + "/mj-single-svg";  // file name prefix to use for temp files
+var tmpfile = os.tmpdir() + "/mj-single-svg" +  Math.floor(Math.random() * 1000);  // file name prefix to use for temp files
 
 var document, window, content, html; // the DOM elements
 


### PR DESCRIPTION
When you have more than 1 request hitting the server at the exact same time, they both try to access the same hard coded filename. This just adds some randomness to the filename so the concurrent requests don't try to use the same temp file.