### PR TITLE
Test corner case that broke the wmf fork

### DIFF
--- a/test/suicide.js
+++ b/test/suicide.js
@@ -1,0 +1,17 @@
+var tape = require('tape');
+var mjAPI = require("..//lib/mj-single.js");
+
+tape('basic test: check MathJax core', function(t) {
+    t.plan(1);
+
+    var tex = "\\underbrace {a \\choose b}";
+    mjAPI.start();
+
+    mjAPI.typeset({
+        math: tex,
+        format: "inline-TeX",
+        mml: true
+    }, function(data) {
+        // this code block will not be reached
+    });
+});


### PR DESCRIPTION
This example breaks the MathJax-node wmf fork
See the output on
https://travis-ci.org/physikerwelt/MathJax-node/builds/95994288
Math Processing Error: Maximum call stack size exceeded
Error: Maximum call stack size exceeded
Thereafter, MathJax-node does not do anything