### PR TITLE
Handle jsdom update in either node4 or node5 directory layout

### DIFF
--- a/lib/patch/jsdom.js
+++ b/lib/patch/jsdom.js
@@ -1,4 +1,16 @@
 //
+//  We need to load cssstyle's parsers.js, but its location differs
+//  between node 4 and node 5, so check which one we have.
+//
+
+var fs = require('fs');
+
+var PARSERS = 'jsdom/node_modules/cssstyle/lib/parsers.js';  // node 4 hierarchy
+try {fs.accessSync(PARSERS, fs.F_OK)} catch (e) {
+  PARSERS = 'cssstyle/lib/parsers.js';  // node 5 heirarchy
+}
+
+//
 //  Patch for CSSStyleDeclaration padding property so that it sets/clears
 //  the Top, Right, Bottom, and Left properties (and also validates the 
 //  padding value)

--- a/lib/patch/jsdom.js
+++ b/lib/patch/jsdom.js
@@ -16,7 +16,7 @@ try {fs.accessSync(PARSERS, fs.F_OK)} catch (e) {
 //  padding value)
 //
 var PADDING = (function () {
-  var parsers = require('jsdom/node_modules/cssstyle/lib/parsers.js');
+  var parsers = require(PARSERS);
   var TYPES = parsers.TYPES;
 
   var isValid = function (v) {
@@ -63,7 +63,7 @@ var PADDING = (function () {
 //  margin value)
 //
 var MARGIN = (function () {
-  var parsers = require('jsdom/node_modules/cssstyle/lib/parsers.js');
+  var parsers = require(PARSERS);
   var TYPES = parsers.TYPES;
 
   var isValid = function (v) {


### PR DESCRIPTION
This should allow the jsdom patch to work in either node4 or node5 hierarchy.