### PR TITLE
Rolling jsdom back to 6.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/mathjax/MathJax-node.git"
   },
   "dependencies": {
-    "jsdom": "7.*",
+    "jsdom": "6.*",
     "mathjax": "*",
     "speech-rule-engine": "*",
     "yargs": "3.*"


### PR DESCRIPTION
It look like in the most recent version 0.5.0, you guys are trying to patch jsdom. In their 7.* version, they no longer use cssstyle which causes errors when trying to load the MathJax module.

**The Error**
```
web-0 Error: Cannot find module 'cssstyle/lib/parsers.js'
web-0     at Function.Module._resolveFilename (module.js:326:15)
web-0     at Function.Module._load (module.js:277:25)
web-0     at Function._load (/usr/local/Cellar/nvm/0.30.1/versions/node/v4.2.6/lib/node_modules/pm2/node_modules/pmx/lib/transaction.js:62:21)
web-0     at Module.require (module.js:354:17)
web-0     at require (internal/module.js:12:17)
web-0     at /Users/sjlu/Code/testable/node_modules/mathjax-node/lib/patch/jsdom.js:51:17
web-0     at Object.<anonymous> (/Users/sjlu/Code/testable/node_modules/mathjax-node/lib/patch/jsdom.js:94:3)
```

**Installed modules for MathJax at 0.5.0**
```
speech-rule-engine@0.2.8 node_modules/speech-rule-engine
├── xpath@0.0.21
├── xmldom@0.1.22
└── commander@2.9.0 (graceful-readlink@1.0.1)

yargs@3.32.0 node_modules/yargs
├── camelcase@2.1.0
├── window-size@0.1.4
├── y18n@3.2.0
├── os-locale@1.4.0 (lcid@1.0.0)
├── decamelize@1.1.2 (escape-string-regexp@1.0.4)
├── string-width@1.0.1 (is-fullwidth-code-point@1.0.0, strip-ansi@3.0.0, code-point-at@1.0.0)
└── cliui@3.1.0 (wrap-ansi@1.0.0, strip-ansi@3.0.0)

tape@4.4.0 node_modules/tape
├── inherits@2.0.1
├── defined@1.0.0
├── resumer@0.0.0
├── has@1.0.1
├── function-bind@1.0.2
├── deep-equal@1.0.1
├── through@2.3.8
├── minimist@1.2.0
├── object-inspect@1.0.2
├── resolve@1.1.7
├── glob@5.0.15 (path-is-absolute@1.0.0, once@1.3.3, inflight@1.0.4, minimatch@3.0.0)
└── string.prototype.trim@1.1.2 (define-properties@1.1.2, es-abstract@1.5.0)

jsdom@7.2.2 node_modules/jsdom
├── webidl-conversions@2.0.1
├── acorn-globals@1.0.9
├── sax@1.1.5
├── abab@1.0.3
├── xml-name-validator@2.0.1
├── symbol-tree@3.1.4
├── tough-cookie@2.2.1
├── nwmatcher@1.3.7
├── cssom@0.3.1
├── whatwg-url-compat@0.6.5 (tr46@0.0.3)
├── parse5@1.5.1
├── acorn@2.7.0
├── escodegen@1.8.0 (estraverse@1.9.3, esutils@2.0.2, esprima@2.7.2, source-map@0.2.0, optionator@0.8.1)
├── request@2.69.0 (aws-sign2@0.6.0, forever-agent@0.6.1, tunnel-agent@0.4.2, oauth-sign@0.8.1, is-typedarray@1.0.0, caseless@0.11.0, stringstream@0.0.5, isstream@0.1.2, json-stringify-safe@5.0.1, extend@3.0.0, node-uuid@1.4.7, qs@6.0.2, combined-stream@1.0.5, form-data@1.0.0-rc3, mime-types@2.1.10, aws4@1.2.1, hawk@3.1.3, bl@1.0.3, har-validator@2.0.6, http-signature@1.1.1)
└── cssstyle@0.2.34

mathjax@2.6.1 node_modules/mathjax
```

**After rolling back jsdom**
```
jsdom@6.5.1 node_modules/jsdom
├── acorn-globals@1.0.9
├── xml-name-validator@2.0.1
├── xmlhttprequest@1.8.0
├── browser-request@0.3.3
├── xtend@4.0.1
├── tough-cookie@2.2.1
├── symbol-tree@3.1.4
├── nwmatcher@1.3.7
├── cssom@0.3.1
├── whatwg-url-compat@0.6.5 (tr46@0.0.3)
├── parse5@1.5.1
├── acorn@2.7.0
├── cssstyle@0.2.34
├── escodegen@1.8.0 (estraverse@1.9.3, esutils@2.0.2, esprima@2.7.2, source-map@0.2.0, optionator@0.8.1)
├── htmlparser2@3.9.0 (domelementtype@1.3.0, entities@1.1.1, domhandler@2.3.0, domutils@1.5.1, readable-stream@2.0.5)
└── request@2.69.0 (aws-sign2@0.6.0, forever-agent@0.6.1, tunnel-agent@0.4.2, oauth-sign@0.8.1, is-typedarray@1.0.0, caseless@0.11.0, stringstream@0.0.5, isstream@0.1.2, json-stringify-safe@5.0.1, extend@3.0.0, node-uuid@1.4.7, qs@6.0.2, combined-stream@1.0.5, form-data@1.0.0-rc3, mime-types@2.1.10, aws4@1.2.1, bl@1.0.3, hawk@3.1.3, http-signature@1.1.1, har-validator@2.0.6)
```