### PR TITLE
Make test for node hierarchy more robust.

### DIFF
--- a/lib/patch/jsdom.js
+++ b/lib/patch/jsdom.js
@@ -3,12 +3,8 @@
 //  between node 4 and node 5, so check which one we have.
 //
 
-var fs = require('fs');
-
-var PARSERS = 'jsdom/node_modules/cssstyle/lib/parsers.js';  // node 4 hierarchy
-try {fs.accessSync('node_modules/'+PARSERS, fs.F_OK)} catch (e) {
-  PARSERS = 'cssstyle/lib/parsers.js';  // node 5 heirarchy
-}
+var PARSERS = 'jsdom/node_modules/cssstyle/lib/parsers.js';             // node 4 hierarchy
+try {require(PARSERS)} catch (e) {PARSERS = 'cssstyle/lib/parsers.js'}  // node 5 heirarchy
 
 //
 //  Companion to implicitSetter, but for the individual parts.


### PR DESCRIPTION
The current test was dependent on the current directory.  My tests were done from the mathjax-node directory itself, but when it is installed with `npm install mathjax-node`, rather than getting a copy of mathjax-node from github and running `npm install` in it, you get a `node_modules` directory, and so the current directory is not the same as what I was using, and the test for node version 4 failed, and it tried to use the node-5 hierarchy.  This leads to the error reported in issues #172 and #179.

This patch uses a test that doesn't rely on the current directory.