### PR TITLE
Don't include a style in the output when there isn't any math on the page

### DIFF
--- a/bin/page2html
+++ b/bin/page2html
@@ -110,7 +110,7 @@ function processHTML(html,callback) {
     //
     //  Replace the body with the one containing the math.
     //
-    document.body.innerHTML = result.html;
+    document.body.innerHTML = result.html.replace(/(\n|\s)*$/,"");
     //
     //  Remove style element from previous run, if there is one.
     //
@@ -120,9 +120,10 @@ function processHTML(html,callback) {
     //
     //  Move the CHTML styles to the head, and return the HTML document.
     //
-    document.head.appendChild(document.body.firstChild);
+    styles = document.body.removeChild(document.body.firstChild);
+    if (styles.textContent !== "") document.head.appendChild(styles);
     var HTML = "<!DOCTYPE html>\n"+document.documentElement.outerHTML.replace(/^(\n|\s)*/,"");
-    callback(HTML);
+    callback(HTML+"\n");
   });
 }
 

--- a/bin/page2html
+++ b/bin/page2html
@@ -107,7 +107,19 @@ function processHTML(html,callback) {
     linebreaks: argv.linebreaks,
     xmlns:xmlns
   }, function (result) {
+    //
+    //  Replace the body with the one containing the math.
+    //
     document.body.innerHTML = result.html;
+    //
+    //  Remove style element from previous run, if there is one.
+    //
+    var id = document.body.firstChild.id||"MathJax_CHTML_styles";
+    var styles = document.getElementById.call(document.head,id);
+    if (styles) styles.parentNode.removeChild(styles);
+    //
+    //  Move the CHTML styles to the head, and return the HTML document.
+    //
     document.head.appendChild(document.body.firstChild);
     var HTML = "<!DOCTYPE html>\n"+document.documentElement.outerHTML.replace(/^(\n|\s)*/,"");
     callback(HTML);

--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -721,12 +721,12 @@ function AdjustSVG() {
 //
 function AdjustHTML() {
   var nodes, i, callback;
-  if (data.renderer === "CommonHTML" && CHTMLSTYLES) {
+  if (data.renderer === "CommonHTML") {
     //
     //  Add styles
     //
     var styles = document.createElement("style");
-    styles.innerHTML = CHTMLSTYLES;
+    styles.innerHTML = CHTMLSTYLES || "";
     styles.id="MathJax_CHTML_styles";
     content.insertBefore(styles,content.firstChild);
   }

--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -721,7 +721,7 @@ function AdjustSVG() {
 //
 function AdjustHTML() {
   var nodes, i, callback;
-  if (data.renderer === "CommonHTML") {
+  if (data.renderer === "CommonHTML" && CHTMLSTYLES) {
     //
     //  Add styles
     //

--- a/test/issue181-1.js
+++ b/test/issue181-1.js
@@ -1,7 +1,7 @@
 var tape = require('tape');
 var mjAPI = require("../lib/mj-page.js");
 
-tape('page with no math should not add undefined styles', function(t) {
+tape('page with no math should not add undefined styles (issue 181)', function(t) {
   t.plan(1);
 
   var html = "<html><head></head><body><p>testing</p></body>";

--- a/test/issue181-1.js
+++ b/test/issue181-1.js
@@ -1,0 +1,17 @@
+var tape = require('tape');
+var mjAPI = require("../lib/mj-page.js");
+
+tape('page with no math should not add undefined styles', function(t) {
+  t.plan(1);
+
+  var html = "<html><head></head><body><p>testing</p></body>";
+  var result = '<style id="MathJax_CHTML_styles"></style><p>testing</p>'
+  mjAPI.start();
+
+  mjAPI.typeset({
+    html: html,
+    renderer: "CommonHTML"
+  }, function(data) {
+    t.equal(data.html,result, 'HTML with no math has empty style element');
+  });
+});

--- a/test/issue181-2.js
+++ b/test/issue181-2.js
@@ -1,0 +1,11 @@
+var tape = require('tape');
+var execFileSync = require('child_process').execFileSync;
+
+tape('page with no math should not change', function(t) {
+  t.plan(1);
+
+  var html = "<!DOCTYPE html>\n<html><head></head><body><p>testing</p></body></html>\n";
+
+  var result = execFileSync('bin/page2html',{input:html}).toString();
+  t.equal(result,html, 'HTML with no math is unchanged');
+});

--- a/test/issue181-2.js
+++ b/test/issue181-2.js
@@ -1,7 +1,7 @@
 var tape = require('tape');
 var execFileSync = require('child_process').execFileSync;
 
-tape('page with no math should not change', function(t) {
+tape('page with no math should not change (issue 181)', function(t) {
   t.plan(1);
 
   var html = "<!DOCTYPE html>\n<html><head></head><body><p>testing</p></body></html>\n";


### PR DESCRIPTION
Don't include a style in the output when there isn't any math on the page, and remove an old copy of the styles if there was one already, and add some comments about what is going on.

Resolves issue #181