### PR TITLE
Adds semantic tree output mj-single and a demonstrator executable.

### DIFF
--- a/bin/tex2stree
+++ b/bin/tex2stree
@@ -2,13 +2,13 @@
 
 /*************************************************************************
  *
- *  tex2mml
+ *  tex2stree
  *
  *  Uses MathJax to convert a TeX or LaTeX string to a MathML string.
  *
  * ----------------------------------------------------------------------
  *
- *  Copyright (c) 2014 The MathJax Consortium
+ *  Copyright (c) 2016 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/bin/tex2stree
+++ b/bin/tex2stree
@@ -1,0 +1,56 @@
+#! /usr/bin/env node
+
+/*************************************************************************
+ *
+ *  tex2mml
+ *
+ *  Uses MathJax to convert a TeX or LaTeX string to a MathML string.
+ *
+ * ----------------------------------------------------------------------
+ *
+ *  Copyright (c) 2014 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+var mjAPI = require("../lib/mj-single.js");
+
+var argv = require("yargs")
+  .demand(1).strict()
+  .usage("Usage: tex2stree [options] 'math' > file.(json|xml)",{
+    json: {
+      boolean: true,
+      describe: "return semantic tree in Json"
+    },
+    xml: {
+      boolean: true,
+      describe: "return semantic tree in XML"
+    }
+  })
+  .argv;
+
+mjAPI.config({});
+mjAPI.start();
+
+mjAPI.typeset({
+  math: argv._[0],
+  format: "TeX",
+  semantic: true
+}, function (data) {
+  if (!data.errors) {
+    if (argv.xml) {
+      console.log(data.streeXml);}
+    if (argv.json) {
+      console.log(JSON.stringify(data.streeJson));}
+    }
+});

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -525,7 +525,7 @@ function AddError(message,nopush) {
 //  into account)
 //
 function GetMML(result) {
-  if (!data.mml && !data.speakText) return;
+  if (!data.mml && !data.speakText && !data.semantic) return;
   var jax = MathJax.Hub.getAllJax()[0];
   try {result.mml = jax.root.toMathML('',jax)} catch(err) {
     if (!err.restart) {throw err;} // an actual error
@@ -556,10 +556,6 @@ function GetSpeech(result) {
 //
 function GetSemantic(result) {
   if (!data.semantic) return;
-  if (!result.mml) {
-    data.mml = true ;
-    GetMML(result);
-  }
   result.streeJson = speech.toJson(result.mml);
   result.streeXml = speech.toSemantic(result.mml);
 }
@@ -720,8 +716,8 @@ function StartQueue() {
     $$("Typeset",HUB),
     $$(TypesetDone,result),
     $$(GetMML,result),
-    $$(GetSpeech,result),
     $$(GetSemantic,result),
+    $$(GetSpeech,result),
     $$(GetHTML,result),
     $$(RerenderSVG,result),
     $$(GetSVG,result),

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -68,6 +68,8 @@ var defaults = {
   speakRuleset: "mathspeak",      // set speech ruleset (default (chromevox rules), mathspeak)
   speakStyle: "default",          // set speech style (mathspeak:  default, brief, sbrief)
 
+  semantic: false,                // adds semantic tree information to output
+  
   timeout: 10 * 1000,             // 10 second timeout before restarting MathJax
 };
 
@@ -549,6 +551,20 @@ function GetSpeech(result) {
 }
 
 //
+//  Creates the semantic tree for the current element and attaches it as JSON
+//  and XML.
+//
+function GetSemantic(result) {
+  if (!data.semantic) return;
+  if (!result.mml) {
+    data.mml = true ;
+    GetMML(result);
+  }
+  result.streeJson = speech.toJson(result.mml);
+  result.streeXml = speech.toSemantic(result.mml);
+}
+
+//
 //  Create HTML and CSS output, if requested
 //
 function GetHTML(result) {
@@ -705,6 +721,7 @@ function StartQueue() {
     $$(TypesetDone,result),
     $$(GetMML,result),
     $$(GetSpeech,result),
+    $$(GetSemantic,result),
     $$(GetHTML,result),
     $$(RerenderSVG,result),
     $$(GetSVG,result),

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -540,14 +540,11 @@ function GetSpeech(result) {
   if (!data.speakText) return;
   speech.setupEngine({semantics: true, domain: data.speakRuleset, style: data.speakStyle});
   result.speakText = speech.toSpeech(result.mml);
-  if (data.mml) {
-    var jax = MathJax.Hub.getAllJax()[0];
-    jax.root.alttext = result.speakText;
-    if (jax.root.attrNames) {jax.root.attrNames.push("alttext")}
-    result.mml = jax.root.toMathML('',jax);
-  } else {
-    delete result.mml;
-  }
+  if (!data.mml) return;
+  var jax = MathJax.Hub.getAllJax()[0];
+  jax.root.alttext = result.speakText;
+  if (jax.root.attrNames) {jax.root.attrNames.push("alttext")}
+  result.mml = jax.root.toMathML('',jax);
 }
 
 //
@@ -788,7 +785,12 @@ function TypesetDone(result) {
 //  do the next queued expression
 //
 function ReturnResult(result) {
-  if (errors.length) {result.errors = errors}
+  if (errors.length) {
+    result.errors = errors;
+  }
+  if (!data.mml) {
+    delete result.mml;
+  }
   callback(result);
   serverState = STATE.READY;
   StartQueue();


### PR DESCRIPTION
Exposes the semantic tree via MathJax-node.
I included the stree computations into the general pipeline. I still feel this is overkill if one wants to only translate TeX into a MML/Stree.
I admit that I have no clue what ConfigureMathJax and StartQueue really do and I would strongly argue for their refactoring into smaller reusable/composable methods.