### PR TITLE
Complete sre scripts

### DIFF
--- a/bin/am2stree
+++ b/bin/am2stree
@@ -1,0 +1,62 @@
+#! /usr/bin/env node
+
+/*************************************************************************
+ *
+ *  am2stree
+ *
+ *  Uses MathJax to convert a AsciiMath string to SRE's semantic tree.
+ *
+ * ----------------------------------------------------------------------
+ *
+ *  Copyright (c) 2016 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+var mjAPI = require("../lib/mj-single.js");
+
+var argv = require("yargs")
+  .demand(1).strict()
+  .usage("Usage: am2stree [options] 'math' > file.(json|xml)",{
+    min: {
+      boolean: true,
+      describe: "minimise output"
+    },
+    json: {
+      boolean: true,
+      describe: "return semantic tree in Json"
+    },
+    xml: {
+      boolean: true,
+      describe: "return semantic tree in XML"
+    }
+  })
+  .argv;
+
+mjAPI.config({});
+mjAPI.start();
+
+mjAPI.typeset({
+  math: argv._[0],
+  format: "AsciiMath",
+  semantic: true,
+  minSTree: argv.min
+}, function (data) {
+  if (!data.errors) {
+    if (argv.xml) {
+      console.log(data.streeXml);}
+    if (argv.json) {
+      console.log(argv.min ? JSON.stringify(data.streeJson) :
+                  JSON.stringify(data.streeJson, null, 2));}
+    }
+});

--- a/bin/mml2stree
+++ b/bin/mml2stree
@@ -1,0 +1,62 @@
+#! /usr/bin/env node
+
+/*************************************************************************
+ *
+ *  mml2stree
+ *
+ *  Uses MathJax to convert a MathML string to SRE's semantic tree.
+ *
+ * ----------------------------------------------------------------------
+ *
+ *  Copyright (c) 2016 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+var mjAPI = require("../lib/mj-single.js");
+
+var argv = require("yargs")
+  .demand(1).strict()
+  .usage("Usage: mml2stree [options] 'math' > file.(json|xml)",{
+    min: {
+      boolean: true,
+      describe: "minimise output"
+    },
+    json: {
+      boolean: true,
+      describe: "return semantic tree in Json"
+    },
+    xml: {
+      boolean: true,
+      describe: "return semantic tree in XML"
+    }
+  })
+  .argv;
+
+mjAPI.config({});
+mjAPI.start();
+
+mjAPI.typeset({
+  math: argv._[0],
+  format: "MathML",
+  semantic: true,
+  minSTree: argv.min
+}, function (data) {
+  if (!data.errors) {
+    if (argv.xml) {
+      console.log(data.streeXml);}
+    if (argv.json) {
+      console.log(argv.min ? JSON.stringify(data.streeJson) :
+                  JSON.stringify(data.streeJson, null, 2));}
+    }
+});

--- a/bin/tex2stree
+++ b/bin/tex2stree
@@ -4,7 +4,7 @@
  *
  *  tex2stree
  *
- *  Uses MathJax to convert a TeX or LaTeX string to a MathML string.
+ *  Uses MathJax to convert a TeX or LaTeX string to SRE's semantic tree.
  *
  * ----------------------------------------------------------------------
  *


### PR DESCRIPTION
Adds the scripts to translate MathML and AsciiMath to semantic tree.

Further to our previous conversation: I really believe we should have a single binary with tons of options here, because I feel this is what people will (want to) use, instead of writing their own little wrappers.