### PR TITLE
Use <script> tags rather than delimited math in mj-single.

### DIFF
--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -106,7 +106,7 @@ var ID = 0;           // id for this SVG element
 //  The delimiters used for each of the input formats
 //
 var TYPES = {
-  TeX: "tex;display=block",
+  TeX: "tex; mode=display",
   "inline-TeX": "tex",
   AsciiMath: "asciimath",
   MathML: "mml"

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -105,11 +105,11 @@ var ID = 0;           // id for this SVG element
 //
 //  The delimiters used for each of the input formats
 //
-var delimiters = {
-  TeX: ["$$","$$"],
-  "inline-TeX": ["$","$"],
-  AsciiMath: ["`","`"],
-  MathML: ["",""]
+var TYPES = {
+  TeX: "tex;display=block",
+  "inline-TeX": "tex",
+  AsciiMath: "asciimath",
+  MathML: "mml"
 };
 
 var CHTMLSTYLES;         // filled in when CommonHTML is loaded
@@ -677,11 +677,8 @@ function StartQueue() {
   //
   var item = queue.shift();
   data = item[0]; callback = item[1];
-  var delim = delimiters[data.format];
-  var math = data.math;
-  if (data.format !== "MathML")
-    math = math.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
-  content.innerHTML = delim[0]+math+delim[1];
+  content.innerHTML = "";
+  MathJax.HTML.addElement(content,"script",{type: "math/"+TYPES[data.format]},[data.math]);
   html.setAttribute("xmlns:"+data.xmlns,"http://www.w3.org/1998/Math/MathML");
 
   //
@@ -858,7 +855,7 @@ exports.typeset = function (data,callback) {
     options[id] = (data.hasOwnProperty(id) ? data[id]: defaults[id]);
   }}
   if (data.state) {options.state = data.state}
-  if (!delimiters[options.format]) {ReportError("Unknown format: "+options.format,callback); return}
+  if (!TYPES[options.format]) {ReportError("Unknown format: "+options.format,callback); return}
   queue.push([options,callback]);
   if (serverState == STATE.STOPPED) {RestartMathJax()}
   if (serverState == STATE.READY) StartQueue();

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -132,7 +132,9 @@ function GetWindow() {
   window.addEventListener("error",function (event) {AddError("Error: "+event.error.stack)});
   content = document.body.appendChild(document.createElement("div"));
   content.id = "MathJax_Content";
-  content.innerHTML = "$x$ `x` <math><mi>x</mi></math>";
+  content.innerHTML = '<script type="math/tex">x</script>' +
+                      '<script type="math/asciimath">x</script>' +
+                      '<script type="math/mml"<<math><mi>x</mi></math></script>';
   //
   //  Node's url.resolve() has a problem with resolving a file:// URL when
   //  the base URL is "about:blank", so force it to be something else (HACK)
@@ -154,7 +156,7 @@ function ConfigureMathJax() {
     //    (users can override that)
     //
     jax: ["input/TeX", "input/MathML", "input/AsciiMath", "output/SVG", "output/CommonHTML"],
-    extensions: ["tex2jax.js","mml2jax.js","asciimath2jax.js","toMathML.js"],
+    extensions: ["toMathML.js"],
     TeX: {extensions: window.Array("AMSmath.js","AMSsymbols.js","autoload-all.js")},
     tex2jax: {inlineMath: [['$','$'],['\\(','\\)']], preview:"none"},
     mml2jax: {preview:"none"},

--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -134,7 +134,7 @@ function GetWindow() {
   content.id = "MathJax_Content";
   content.innerHTML = '<script type="math/tex">x</script>' +
                       '<script type="math/asciimath">x</script>' +
-                      '<script type="math/mml"<<math><mi>x</mi></math></script>';
+                      '<script type="math/mml"><math><mi>x</mi></math></script>';
   //
   //  Node's url.resolve() has a problem with resolving a file:// URL when
   //  the base URL is "about:blank", so force it to be something else (HACK)


### PR DESCRIPTION
This resolves the problem of having delimiters as part of the math passed to mj-single, and also prevents the need for the preprocessors.

[Fixes #226]