### PR TITLE
Removes sre from mathjax node.

### DIFF
--- a/bin/tex2html
+++ b/bin/tex2html
@@ -24,6 +24,7 @@
  */
 
 var mjAPI = require("../lib/main.js");
+var speech = require('../lib/speech.js');                    //  Speech integraton helper functions.
 
 var argv = require("yargs")
   .demand(1).strict()
@@ -78,11 +79,14 @@ mjAPI.typeset({
   math: argv._[0],
   format: (argv.inline ? "inline-TeX" : "TeX"),
   html:true, css: argv.css,
-  speakText: argv.speech,
-  speakRuleset: argv.speechrules.replace(/^chromevox$/i,"default"),
-  speakStyle: argv.speechstyle,
+  mml: argv.speech,
   ex: argv.ex, width: argv.width,
   linebreaks: argv.linebreaks
 }, function (data) {
-  if (!data.errors) {console.log(argv.css ? data.css : data.html)}
+  if (!data.errors) {
+    console.log(argv.speech ?
+                speech.generate(data.htmlElement, data.mml,
+                                argv.speechrules, argv.speechstyle) :
+                data.html);
+  }
 });

--- a/bin/tex2htmlcss
+++ b/bin/tex2htmlcss
@@ -24,6 +24,7 @@
  */
 
 var mjAPI = require("../lib/main.js");
+var speech = require('../lib/speech.js');                    //  Speech integraton helper functions.
 
 var argv = require("yargs")
   .demand(1).strict()
@@ -74,9 +75,7 @@ mjAPI.typeset({
   math: argv._[0],
   format: (argv.inline ? "inline-TeX" : "TeX"),
   html:true, css: true,
-  speakText: argv.speech,
-  speakRuleset: argv.speechrules.replace(/^chromevox$/i,"default"),
-  speakStyle: argv.speechstyle,
+  mml: argv.speech,
   ex: argv.ex, width: argv.width,
   linebreaks: argv.linebreaks
 }, function (data) {
@@ -86,7 +85,10 @@ mjAPI.typeset({
     console.log("<title></title>\n<style>");
     console.log(data.css);
     console.log("</style>\n</head>\n<body>");
-    console.log(data.html);
+    console.log(argv.speech ?
+                speech.generate(data.htmlElement, data.mml,
+                                argv.speechrules, argv.speechstyle) :
+                data.html);
     console.log("</body>\n</html>");
   }
 });

--- a/bin/tex2mml
+++ b/bin/tex2mml
@@ -24,6 +24,7 @@
  */
 
 var mjAPI = require("../lib/main.js");
+var speech = require('../lib/speech.js');                    //  Speech integraton helper functions.
 
 var argv = require("yargs")
   .demand(1).strict()
@@ -73,10 +74,12 @@ mjAPI.start();
 mjAPI.typeset({
   math: argv._[0],
   format: (argv.inline ? "inline-TeX" : "TeX"),
-  mml:true,
-  speakText: argv.speech,
-  speakRuleset: argv.speechrules.replace(/^chromevox$/i,"default"),
-  speakStyle: argv.speechstyle
+  mml:true
 }, function (data) {
-  if (!data.errors) {console.log(data.mml)}
+  if (!data.errors) {
+    console.log(argv.speech ?
+                speech.generate(data.mmlElement, data.mml,
+                                argv.speechrules, argv.speechstyle) :
+                data.mml);
+  }
 });

--- a/bin/tex2stree
+++ b/bin/tex2stree
@@ -24,6 +24,7 @@
  */
 
 var mjAPI = require("../lib/main.js");
+var sre = require('speech-rule-engine');
 
 var argv = require("yargs")
   .demand(1).strict()
@@ -49,14 +50,16 @@ mjAPI.start();
 mjAPI.typeset({
   math: argv._[0],
   format: "TeX",
-  semantic: true,
-  minSTree: argv.min
+  mml: true
 }, function (data) {
   if (!data.errors) {
     if (argv.xml) {
-      console.log(data.streeXml);}
+      var semantic = sre.toSemantic(data.mml).toString();
+      console.log(argv.min ?  semantic : sre.pprintXML(semantic));
+    }
     if (argv.json) {
-      console.log(argv.min ? JSON.stringify(data.streeJson) :
-                  JSON.stringify(data.streeJson, null, 2));}
+      var json = sre.toJson(data.mml);
+      console.log(argv.min ? JSON.stringify(json) :
+                  JSON.stringify(json, null, 2));}
     }
 });

--- a/bin/tex2svg
+++ b/bin/tex2svg
@@ -24,6 +24,7 @@
  */
 
 var mjAPI = require("../lib/main.js");
+var speech = require('../lib/speech.js');                    //  Speech integraton helper functions.
 
 var argv = require("yargs")
   .demand(1).strict()
@@ -75,11 +76,14 @@ mjAPI.typeset({
   math: argv._[0],
   format: (argv.inline ? "inline-TeX" : "TeX"),
   svg:true,
-  speakText: argv.speech,
-  speakRuleset: argv.speechrules.replace(/^chromevox$/i,"default"),
-  speakStyle: argv.speechstyle,
+  mml: argv.speech,
   ex: argv.ex, width: argv.width,
   linebreaks: argv.linebreaks
 }, function (data) {
-  if (!data.errors) {console.log(data.svg)}
+  if (!data.errors) {
+    console.log(argv.speech ?
+                speech.generate(data.svgElement, data.mml,
+                                argv.speechrules, argv.speechstyle) :
+                data.svg);
+  }
 });

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,7 +31,6 @@ var fs = require('fs');
 var path = require('path');
 var url = require('url');
 var jsdom = require('jsdom').jsdom;
-var speech = require('speech-rule-engine');
 
 require('./patch/jsdom.js').patch(jsdom);  //  Fix some bugs in jsdom
 
@@ -54,16 +53,12 @@ var defaults = {
   xmlns: "mml",                   // the namespace to use for MathML
 
   html: false,                    // return HTML output?
+  htmlElement: null,              // DOM element for HTML output.
   css: false,                     // return CSS for HTML output?
   mml: false,                     // return mml output?
+  mmlElement: null,               // DOM element for MML output.
   svg: false,                     // return svg output?
-
-  speakText: false,               // add spoken annotations to svg output?
-  speakRuleset: "mathspeak",      // set speech ruleset (default (chromevox rules), mathspeak)
-  speakStyle: "default",          // set speech style (mathspeak:  default, brief, sbrief)
-
-  semantic: false,                // adds semantic tree information to output
-  minSTree: false,                // if false the semantic tree is pretty printed
+  svgElement: null,               // DOM element for SVG output.
 
   timeout: 10 * 1000,             // 10 second timeout before restarting MathJax
 };
@@ -517,41 +512,14 @@ function AddError(message,nopush) {
 //  into account)
 //
 function GetMML(result) {
-  if (!data.mml && !data.speakText && !data.semantic) return;
+  if (!data.mml) return;
   var jax = MathJax.Hub.getAllJax()[0];
   try {result.mml = jax.root.toMathML('',jax)} catch(err) {
     if (!err.restart) {throw err;} // an actual error
     return MathJax.Callback.After(window.Array(GetMML,result),err.restart);
   }
-}
-
-//
-//  Creates the speech string and updates the MathML to include it, if needed
-//
-function GetSpeech(result) {
-  if (!data.speakText) return;
-  speech.setupEngine({semantics: true, domain: data.speakRuleset, style: data.speakStyle});
-  result.speakText = speech.toSpeech(result.mml);
-  if (!data.mml) return;
-  var jax = MathJax.Hub.getAllJax()[0];
-  jax.root.alttext = result.speakText;
-  var attrNames = jax.root.attrNames;
-  if (attrNames && attrNames.indexOf("alttext") === -1) {
-    attrNames.push("alttext");
-  }
-  result.mml = jax.root.toMathML('',jax);
-}
-
-//
-//  Creates the semantic tree for the current element and attaches it as JSON
-//  and XML.
-//
-function GetSemantic(result) {
-  if (!data.semantic) return;
-  result.streeJson = speech.toJson(result.mml);
-  result.streeXml = data.minSTree ?
-    speech.toSemantic(result.mml) :
-    speech.pprintXML(speech.toSemantic(result.mml));
+  //TODO: Put this in a try.
+  result.mmlElement = jsdom(result.mml).body.firstChild;
 }
 
 //
@@ -562,13 +530,6 @@ function GetHTML(result) {
   var jax = MathJax.Hub.getAllJax()[0]; if (!jax) return;
   var script = jax.SourceElement(), html = script.previousSibling;
 
-  if (data.speakText) {
-    var label = html.querySelector("[aria-label]");
-    if (label) label.removeAttribute("aria-label");
-    html.setAttribute("aria-label",result.speakText);
-    for (var i=0, m=html.childNodes.length; i < m; i++)
-      html.childNodes[i].setAttribute("aria-hidden",true);
-  }
   // remove automatically generated IDs
   var ids = html.querySelectorAll('[id^="MJXc-Node-"]');
   for (var i = 0; i < ids.length; i++){
@@ -585,6 +546,7 @@ function GetHTML(result) {
     // otherwise (inline-mode) the frame is the root element
     html.removeAttribute("id");
   }
+  result.htmlElement = html;
   result.html = html.outerHTML;
   if (data.css) result.css = CHTMLSTYLES;
 }
@@ -599,20 +561,15 @@ function GetSVG(result) {
       svg = script.previousSibling.getElementsByTagName("svg")[0];
   svg.setAttribute("xmlns","http://www.w3.org/2000/svg");
 
-  //
-  //  Add the speech text and mark the SVG appropriately
-  //
-  if (data.speakText) {
-    ID++; var id = "MathJax-SVG-"+ID;
-    svg.removeAttribute("aria-label");
-    svg.setAttribute("aria-labelledby",id+"-Title "+id+"-Desc");
-    for (var i=0, m=svg.childNodes.length; i < m; i++)
-      svg.childNodes[i].setAttribute("aria-hidden",true);
-    var node = MathJax.HTML.Element("desc",{id:id+"-Desc"},[result.speakText]);
-    svg.insertBefore(node,svg.firstChild);
-    node = MathJax.HTML.Element("title",{id:id+"-Title"},["Equation"]);
-    svg.insertBefore(node,svg.firstChild);
-  }
+  ID++; var id = "MathJax-SVG-"+ID;
+  svg.removeAttribute("aria-label");
+  svg.setAttribute("aria-labelledby",id+"-Title "+id+"-Desc");
+  for (var i=0, m=svg.childNodes.length; i < m; i++)
+    svg.childNodes[i].setAttribute("aria-hidden",true);
+  var node = MathJax.HTML.Element("desc",{id:id+"-Desc"},[data.math]);
+  svg.insertBefore(node,svg.firstChild);
+  node = MathJax.HTML.Element("title",{id:id+"-Title"},["Equation"]);
+  svg.insertBefore(node,svg.firstChild);
 
   //
   //  SVG data is modified to add linebreaks for readability,
@@ -626,6 +583,7 @@ function GetSVG(result) {
   //  Add the requested data to the results
   //
   result.svg = svgdata;
+  result.svgElement = svg;
   result.width = svg.getAttribute("width");
   result.height = svg.getAttribute("height");
   result.style =  svg.style.cssText;
@@ -681,7 +639,7 @@ function StartQueue() {
 
   //
   //  Set up a timeout timer to restart MathJax if it runs too long,
-  //  Then push the Typeset call, the MathML, speech, and SVG calls,
+  //  Then push the Typeset call, the MathML, and SVG calls,
   //  and our TypesetDone routine
   //
   timer = setTimeout(RestartMathJax,data.timeout);
@@ -690,8 +648,6 @@ function StartQueue() {
     $$("Typeset",HUB),
     $$(TypesetDone,result),
     $$(GetMML,result),
-    $$(GetSemantic,result),
-    $$(GetSpeech,result),
     $$(GetHTML,result),
     $$(RerenderSVG,result),
     $$(GetSVG,result),

--- a/lib/speech.js
+++ b/lib/speech.js
@@ -25,14 +25,12 @@
 
 var speechGen = {};
 
-speechGen.sre = require('speech-rule-engine');
-
 
 /**
- * An id counter.
- * @type {number}
+ * The sre package.
+ * @type {Object}
  */
-speechGen.id = 0;
+speechGen.sre = require('speech-rule-engine');
 
 
 speechGen.call = function() {
@@ -42,21 +40,13 @@ speechGen.call = function() {
 };
 
 
-speechGen.injectInSVG_ = function(svg, speech, counter) {
-  //TODO: What if desc element does not exist?
-  var descr = svg.querySelector('desc');
-  descr.textContent = speech;
-};
-
-
-speechGen.inject = function(element, speech, opt_counter) {
+speechGen.inject = function(element, speech) {
   if (!speech) return;
   var tagName = element.tagName.toUpperCase();
-  var id = opt_counter || speechGen.id++;
   switch (tagName) {
     // SVG
     case 'SVG':
-    speechGen.injectInSVG_(element, speech, id);
+    speechGen.injectInSVG_(element, speech);
     return;
     // MML
     case 'MATH':
@@ -66,6 +56,13 @@ speechGen.inject = function(element, speech, opt_counter) {
     default:
     speechGen.injectInHTML_(element, speech);
   }
+};
+
+
+speechGen.injectInSVG_ = function(svg, speech) {
+  //TODO: What if desc element does not exist?
+  var descr = svg.querySelector('desc');
+  descr.textContent = speech;
 };
 
 
@@ -115,5 +112,4 @@ speechGen.generate = function(element, mml, domain, style) {
 
 
 exports.generate = speechGen.generate;
-exports.sre = speechGen.sre;
 

--- a/lib/speech.js
+++ b/lib/speech.js
@@ -1,0 +1,119 @@
+/*********************************************************************
+ *
+ *  speech.js
+ *
+ *  Some utility functions to embed speech strings into MathJax-node output.
+ *
+ * ----------------------------------------------------------------------
+ *
+ *  Copyright (c) 2014--2016 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Speech helper functions.
+
+var speechGen = {};
+
+speechGen.sre = require('speech-rule-engine');
+
+
+/**
+ * An id counter.
+ * @type {number}
+ */
+speechGen.id = 0;
+
+
+speechGen.call = function() {
+  return speechGen.sre ?
+    function(x) {return speechGen.sre.toSpeech(x);} :
+  function(x) {return '';};
+};
+
+
+speechGen.injectInSVG_ = function(svg, speech, counter) {
+  //TODO: What if desc element does not exist?
+  var descr = svg.querySelector('desc');
+  descr.textContent = speech;
+};
+
+
+speechGen.inject = function(element, speech, opt_counter) {
+  if (!speech) return;
+  var tagName = element.tagName.toUpperCase();
+  var id = opt_counter || speechGen.id++;
+  switch (tagName) {
+    // SVG
+    case 'SVG':
+    speechGen.injectInSVG_(element, speech, id);
+    return;
+    // MML
+    case 'MATH':
+    speechGen.injectInMML_(element, speech);
+    return;
+    // HTML
+    default:
+    speechGen.injectInHTML_(element, speech);
+  }
+};
+
+
+speechGen.injectInMML_ = function(mml, speech) {
+  mml.setAttribute('alttext', speech);
+};
+
+
+speechGen.injectInHTML_ = function(html, speech) {
+  var label = html.querySelector('[aria-label]');
+  if (label) {
+    label.removeAttribute('aria-label');
+  }
+  html.setAttribute('aria-label', speech);
+  for (var i = 0, m = html.childNodes.length; i < m; i++) {
+    html.childNodes[i].setAttribute('aria-hidden', true);
+  }
+};
+
+
+speechGen.string = function(element) {
+  var str = element.outerHTML;
+  return speechGen.sre ? speechGen.sre.pprintXML(str).replace(/\W$/, '') : str;
+};
+
+
+/**
+ * Generate speech output and inject it into a DOM element.
+ * @param {Element} element A DOM element.
+ * @param {string} mml The MathML string.
+ * @param {string} domain Speech rule set for sre.
+ * @param {string} style Speech style for sre.
+ * @return {string} The serialised element.
+ */
+speechGen.generate = function(element, mml, domain, style) {
+  speechGen.sre.setupEngine(
+    {
+      domain: domain.replace(/^chromevox$/i,"default"),
+      style: style,
+      semantics: true
+    }
+  );
+  var text = speechGen.call()(mml);
+  speechGen.inject(element, text);
+  return speechGen.string(element);
+};
+
+
+exports.generate = speechGen.generate;
+exports.sre = speechGen.sre;
+


### PR DESCRIPTION
The PR removes SRE from MathJax-node core as discussed in issue #207. Here are the main changes and/or points to discuss:
- All references to speech are taken out of main.js
- A new speech.js file offeres some helper functionality. However, I could see the main method that injects speech into a DOM node move into sre api.
- As examples all the bin/tex2\* have been adapted to the new code.
- I have introduced new htmlElement, svgElement, mmlElement fields to return the actual DOM elements in the data object. Note, that the mmlElement has to be explicitly created.
- SVG now comes with title and desc element by default. The latter contains the original input code. Not sure if that makes sense in the MathML case.
