### PR TITLE
Fixed bug with equation numbers not resetting to 0

### DIFF
--- a/lib/mj-page.js
+++ b/lib/mj-page.js
@@ -641,7 +641,7 @@ function ConfigureTypeset() {
   //  Reset the MathJax counters for things
   //
   SVG.resetGlyphs(true);
-  if (TEX.resetEquationNUmbers) TEX.resetEquationNumbers();
+  if (TEX.resetEquationNumbers) TEX.resetEquationNumbers();
   MML.SUPER.ID = 0;
 
   //


### PR DESCRIPTION
If `typeset()` was called multiple times *without* a call to `start()` in between, the equation numbering does not reset to 0. Unfortunately, always calling `start()` causes undefined behaviour.

In my tests for [gulp-mathjax-node](https://github.com/cemrajc/gulp-mathjax-node), I found this was an issue with the `mj-page.js` file.

Admittedly, this is a *very* hard-to-spot error :smile: 