### PR TITLE
Fix jsdom patch to work with version 9.  #266

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -117,7 +117,7 @@ var CHTMLSTYLES;         // filled in when CommonHTML is loaded
 //    the jax to be loaded completely)
 //
 function GetWindow() {
-  document = jsdom();
+  document = jsdom('',{userAgent: "Node.js"});
   html = document.firstChild;
   window = document.defaultView;
   window.console = console;

--- a/lib/patch/jsdom.js
+++ b/lib/patch/jsdom.js
@@ -49,10 +49,11 @@ var PADDING = (function () {
 
   var isValid = function (v) {
     var type = parsers.valueType(v);
-    return type === TYPES.LENGTH || type === TYPES.PERCENT || type === TYPES.INTEGER;
+    return type === TYPES.LENGTH || type === TYPES.PERCENT || v === "0";
   };
 
   var parser = function (v) {
+    if (v === "0") return "0px";
     return parsers.parseMeasurement(v);
   };
   
@@ -101,12 +102,13 @@ var MARGIN = (function () {
   var isValid = function (v) {
     if (v.toLowerCase() === "auto") return true;
     var type = parsers.valueType(v);
-    return type === TYPES.LENGTH || type === TYPES.PERCENT || type === TYPES.INTEGER;
+    return type === TYPES.LENGTH || type === TYPES.PERCENT || v === "0";
   };
 
   var parser = function (v) {
     var V = v.toLowerCase();
     if (V === "auto") return V;
+    if (v === "0") return "0px";
     return parsers.parseMeasurement(v);
   };
 
@@ -322,19 +324,19 @@ exports.patch = function (jsdom) {
   div.style.paddingTop = "10px";
   div.style.padding = "1px";
   if (div.style.paddingTop !== "1px") {
-    var core = require("jsdom/lib/jsdom/level1/core");
+    var core = require("jsdom/lib/jsdom/living");
     Object.defineProperties(core.CSSStyleDeclaration.prototype,{
       padding: PADDING.definition,
       margin: MARGIN.definition
     });
   }
   //
-  //  Check if pixels without "px" are OK
+  //  Check if 0 pixels without "px" is OK
   //
   div.style.padding = "";
-  div.style.padding = "1px 2 3px 4";
-  if (div.style.padding !== "1px 2 3px 4") {
-    var core = require("jsdom/lib/jsdom/level1/core");
+  div.style.padding = "1px 0 3px 4px";
+  if (div.style.padding !== "1px 0px 3px 4px") {
+    var core = require("jsdom/lib/jsdom/living");
     Object.defineProperties(core.CSSStyleDeclaration.prototype,{
       padding: PADDING.definition,
       margin: MARGIN.definition
@@ -346,7 +348,7 @@ exports.patch = function (jsdom) {
   div.style.padding = "1px 2px 3px 4px";
   div.style.paddingTop = "10px";
   if (div.style.padding !== "10px 2px 3px 4px") {
-    var core = require("jsdom/lib/jsdom/level1/core");
+    var core = require("jsdom/lib/jsdom/living");
     Object.defineProperties(core.CSSStyleDeclaration.prototype,{
       marginTop: {
         set: subImplicitSetter('margin', 'top', MARGIN.isValid, MARGIN.parser),
@@ -403,7 +405,7 @@ exports.patch = function (jsdom) {
   //
   div.style.width = "auto";
   if (div.style.width !== "auto") {
-    var core = require("jsdom/lib/jsdom/level1/core");
+    var core = require("jsdom/lib/jsdom/living");
     Object.defineProperties(core.CSSStyleDeclaration.prototype,{width: WIDTH});
   }
   //

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/mathjax/MathJax-node.git"
   },
   "dependencies": {
-    "jsdom": "7.*",
+    "jsdom": "7.0 - 9.8",
     "mathjax": "*",
     "speech-rule-engine": "*",
     "yargs": "3.*"


### PR DESCRIPTION
Fix jsdom patch to work with version 9 as well as version 7, and set user agent since the one in version 9 now makes MathJax think it is Safari.  Resolves issue #266.
