### PR TITLE
Add missing pxPerInch value.  #275

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -245,6 +245,7 @@ function ConfigureMathJax() {
           //  Set up the default ex-size and width
           //
           InitializeSVG: function () {
+            this.pxPerInch    = 96;
             this.defaultEx    = 6;
             this.defaultWidth = 100;
           },

--- a/test/issue276.js
+++ b/test/issue276.js
@@ -1,0 +1,20 @@
+var tape = require('tape');
+var mjAPI = require("../lib/main.js");
+var jsdom = require('jsdom').jsdom;
+
+tape('SVG output: physical units', function(t) {
+  t.plan(1);
+  mjAPI.start();
+  var mml = '<math><mspace width="1cm"></mspace></math>';
+
+  mjAPI.typeset({
+    math: mml,
+    format: "MathML",
+    svg: true
+  }, function(data) {
+    var document = jsdom(data.svg);
+    var doc = document.defaultView.document;
+    var width =  doc.querySelector('svg').getAttribute('width');
+    t.notEqual(width, '0', '');
+  });
+});


### PR DESCRIPTION
This defines the `pxPerInch` value needed for absolute units like `cm`, `mm`, `in`, etc. that is usually computed by measuring DOM elements.  Resolves #275.