### PR TITLE
Don't produce mml when mmlNode is requested if mml wasn't requested. #277

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -537,12 +537,13 @@ function GetMML(result) {
     }
   }
   try {
-    result.mml = jax.root.toMathML('',jax);
-    if (data.mmlNode) result.mmlNode = jsdom(result.mml).body.firstChild;
+    var mml = jax.root.toMathML('',jax);
   } catch(err) {
     if (!err.restart) {throw err;} // an actual error
     return MathJax.Callback.After(window.Array(GetMML,result),err.restart);
   }
+  if (data.mml) result.mml = mml;
+  if (data.mmlNode) result.mmlNode = jsdom(mml).body.firstChild;
 }
 
 //

--- a/test/issue277.js
+++ b/test/issue277.js
@@ -1,7 +1,7 @@
 var tape = require('tape');
 var mjAPI = require("../lib/main.js");
 
-tape('mmlNode should enable mml', function(t) {
+tape('mmlNode should not produce mml', function(t) {
     t.plan(1);
     mjAPI.start();
     var tex = 'x';
@@ -11,6 +11,6 @@ tape('mmlNode should enable mml', function(t) {
         format: "TeX",
         mmlNode: true
     }, function(data) {
-        t.ok(data.mml, 'MathML generated');
+        t.ok(data.mml === undefined, 'mml not generated');
     });
 });


### PR DESCRIPTION
Don't produce `mml` when `mmlNode` is produced (unless `mml` is also requested).  Fixes a problem with PR #282, and resolves #277.