### PR TITLE
exports.start() accepts a callback to get MathJax

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -844,7 +844,19 @@ exports.typeset = function (data,callback) {
 //  Manually start MathJax (this is done automatically
 //  when the first typeset() call is made)
 //
-exports.start = function () {RestartMathJax()}
+//  E.g.
+//     mjAPI.start(function (MathJax) {
+//       MathJax.Hub.Register.StartupHook('XXX Ready', function () {
+//         // something you need to run when XXX is ready
+//       }
+//     });
+//
+exports.start = function (callback) {
+  RestartMathJax();
+  exports.typeset({}, function () {
+    callback && callback(window.MathJax);
+  });
+}
 
 //
 //  Configure MathJax and the API


### PR DESCRIPTION
(moved from #319, based on develop branch)

In #318 we discussed how to access the `MathJax` object in mathjax-node. I suggest using the existing `start()` api to do this:
```js
//  E.g.
//     mjAPI.start(function (MathJax) {
//       MathJax.Hub.Register.StartupHook('XXX Ready', function () {
//         // something you need to run when XXX is ready
//       }
//     });
//
exports.start = function (callback) {
  RestartMathJax();
  exports.typeset({}, function () {
    callback && callback(window.MathJax);
  });
}
```

Currently the `start()` API is merely used in practice, because the first `typeset()` already does its job. Therefore I think it may be a reasonable design to make use of `start()` to access the `MathJax` object. 