### PR TITLE
[main] config: sanitize MathJax configuration

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -867,5 +867,9 @@ exports.config = function (config) {
   if (config.undefinedCharError != null) {undefinedChar   = config.undefinedCharError}
   if (config.extensions != null)         {extensions      = config.extensions}
   if (config.fontURL != null)            {fontURL         = config.fontURL}
-  if (config.MathJax) {MathJaxConfig = config.MathJax}
+  if (config.MathJax) {
+    // strip MathJax config blocks to avoid errors
+    if (config.MathJax.config) delete config.MathJax.config
+    MathJaxConfig = config.MathJax
+  }
 }

--- a/test/mathjax-config-combined.js
+++ b/test/mathjax-config-combined.js
@@ -1,0 +1,20 @@
+var tape = require('tape');
+var mjAPI = require("../lib/main.js");
+var jsdom = require('jsdom').jsdom;
+
+tape('MathJax configuration: strip config block', function (t) {
+    t.plan(1);
+    mjAPI.config({
+        MathJax: {
+            config: ["TeX-AMS_SVG.js"]
+        }
+    });
+    mjAPI.typeset({
+        math: 'E = mc^2',
+        format: "TeX",
+        mml: true,
+    }, function (data) {
+        t.ok(data, 'Config block did not cause errors');
+    });
+
+});


### PR DESCRIPTION
Remove `config` array to avoid errors from e.g. loading combined configurations
Fixes #330