### PR TITLE
Define the None output jax after the other jax are loaded

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -486,14 +486,16 @@ function ConfigureMathJax() {
       //
       //  Set up None output jax (for when only MathML output is needed)
       //
-      MathJax.OutputJax.None = MathJax.OutputJax({
-        id: "None",
-        preTranslate: function () {},
-        Translate: function () {},
-        postTranslate: function () {}
+      MathJax.Hub.Register.StartupHook("End Jax", function () {
+        MathJax.OutputJax.None = MathJax.OutputJax({
+          id: "None",
+          preTranslate: function () {},
+          Translate: function () {},
+          postTranslate: function () {}
+        });
+        MathJax.OutputJax.None.loadComplete("jax.js");
+        MathJax.OutputJax.None.Register("jax/mml");
       });
-      MathJax.OutputJax.None.loadComplete("jax.js");
-      MathJax.OutputJax.None.Register("jax/mml");
 
       //
       //  Reset the color extension after `autoload-all`

--- a/test/useFontCache.js
+++ b/test/useFontCache.js
@@ -1,0 +1,24 @@
+var tape = require('tape');
+var mjAPI = require("../lib/main.js");
+
+tape('basic configuration: useFontCache', function (t) {
+    t.plan(2);
+
+    var tex = 'a';
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        svg: true,
+        useFontCache: false
+    }, function (result, data) {
+        t.ok(result.svg.indexOf('<use') === -1, 'useFontCache set to false');
+    });
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        svg: true,
+        useFontCache: true
+    }, function (result, data) {
+        t.ok(result.svg.indexOf('<use') >  -1, 'useFontCache set to true');
+    });
+});


### PR DESCRIPTION
Define the None output jax after the other jax are loaded (so SVG will be loaded initially, so its configuration can be set by hand).  Resolves issue #392.