### PR TITLE
Suppress unwanted error output in tests

### DIFF
--- a/test/base-typeset-promise.js
+++ b/test/base-typeset-promise.js
@@ -5,6 +5,7 @@ tape('basic test: check typeset promise API', function (t) {
     t.plan(2);
 
     var tex = '';
+    mjAPI.config({displayErrors: false});
     mjAPI.start();
 
     // promise resolved

--- a/test/base-warnings.js
+++ b/test/base-warnings.js
@@ -4,6 +4,7 @@ mjAPI.config({undefinedCharError: true});
 
 tape('basic test: check warnings', function (t) {
     t.plan(2);
+    mjAPI.config({displayErrors: false});
     mjAPI.typeset({math:'\u5475', html:true})
         .catch(errors => t.ok(errors, 'CommonHTML output reports error'));
     mjAPI.typeset({math:'\u5475', svg:true})

--- a/test/issue175.js
+++ b/test/issue175.js
@@ -4,6 +4,7 @@ var JSDOM = require('jsdom').JSDOM;
 
 tape('color extension should be reset', function(t) {
   t.plan(3);
+  mjAPI.config({displayErrors: false});
   mjAPI.start();
   var tex = '\\colorbox{green}{x}';
   var tex2 = '\\color{red}{x}x';

--- a/test/svg-full-width-chars.js
+++ b/test/svg-full-width-chars.js
@@ -4,8 +4,9 @@ var mjAPI = require("../lib/main.js");
 tape('the SVG output should renders full-width characters correctly', function(t) {
   t.plan(1);
 
+  mjAPI.config({displayErrors: false});
   mjAPI.start();
-  var tex = '\\text{拾零}^i';
+  var tex = '\\text{\u62FE\u96F6}^i';
 
   mjAPI.typeset({
     math: tex,


### PR DESCRIPTION
This makes the output of running the test suite easier read.  (I also like to pipe it though tap-spec to prettify it even more.)