### PR TITLE
[test] fix base-config-fonturls.js on NodeJS < 8

### DIFF
--- a/test/assets/version.js
+++ b/test/assets/version.js
@@ -1,0 +1,12 @@
+MathJax.Hub.Register.StartupHook("TeX Jax Ready", function () {
+  var TEX = MathJax.InputJax.TeX;
+  var MML = MathJax.ElementJax.mml;
+  TEX.Definitions.macros.version = "Version";
+  TEX.Parse.Augment({
+    Version: function (name) {
+      this.Push(MML.mtext(MathJax.version));
+    }
+  });
+});
+
+MathJax.Ajax.loadComplete("[test]/version.js");

--- a/test/base-config-fonturl.js
+++ b/test/base-config-fonturl.js
@@ -1,16 +1,21 @@
 var tape = require('tape');
 var mjAPI = require("../lib/main.js");
-var mjVersion = require('../package-lock.json').dependencies['mathjax'].version
+var path = require('path');
 
 tape('basic configuration: check fontURL', function (t) {
     t.plan(2);
-
-    var tex = 'a';
+    
+    mjAPI.config({
+        extensions: '[test]/version.js',
+        paths: {test: path.join(__dirname,'assets/')}
+    });
     mjAPI.typeset({
-        math: tex,
+        math: '\\version',
         format: "TeX",
+        mml: true,
         css: true
     }, function (result, data) {
+        var mjVersion = ((result.mml || '').match(/<mtext>(.*)<\/mtext>/) || [])[1] || '';
         t.ok(result.css.indexOf('https://cdnjs.cloudflare.com/ajax/libs/mathjax/' + mjVersion + '/fonts/HTML-CSS') > -1, 'Default fontURL');
     });
     // reconfigure
@@ -18,12 +23,13 @@ tape('basic configuration: check fontURL', function (t) {
         math: ''
     }, function () {
         mjAPI.config({
+            extensions: '',
             fontURL: 'https://example.com'
         });
         mjAPI.start();
     })
     mjAPI.typeset({
-        math: tex,
+        math: 'a',
         format: "TeX",
         css: true,
     }, function (result, data) {


### PR DESCRIPTION
Make version detection use MathJax itself, rather than the package-lock file.