### PR TITLE
Fix start() to handle being called while MathJax is starting up

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -74,7 +74,8 @@ var STATE = {
   STOPPED: 1,          // no DOM or MathJax available
   STARTED: 2,          // DOM loaded, MathJax starting up
   READY:   3,          // MathJax initialized and ready to process math
-  BUSY:    4           // MathJax currently processing math
+  BUSY:    4,          // MathJax currently processing math
+  RESTART: 5,          // start() called while MathJax is starting up
 };
 
 //
@@ -518,8 +519,12 @@ function ConfigureMathJax() {
       MathJax.Hub.Register.StartupHook("End",function () {
         if (MathJax.OutputJax.SVG.resetGlyphs) MathJax.OutputJax.SVG.resetGlyphs(true);
         MathJax.ElementJax.mml.ID = 0;
-        serverState = STATE.READY;
-        MathJax.Hub.Queue(StartQueue);
+        if (serverState === STATE.RESTART) {
+          setTimeout(RestartMathJax, 100);
+        } else {
+          serverState = STATE.READY;
+          MathJax.Hub.Queue(StartQueue);
+        }
       });
     }
   };
@@ -943,12 +948,16 @@ exports.typeset = function (data, callback) {
 
 //
 //  Manually start MathJax (this is done automatically
-//  when the first typeset() call is made), but don't
+//  when the first typeset() call is made), but delay
 //  restart if we are already starting up (prevents
 //  multiple calls to start() from causing confusion).
 //
 exports.start = function () {
-  if (serverState !== STATE.STARTED) RestartMathJax();
+  if (serverState === STATE.STARTED) {
+    serverState = STATE.RESTART;
+  } else if (serverState !== STATE.ABORT) {
+    RestartMathJax();
+  }
 }
 
 //

--- a/lib/main.js
+++ b/lib/main.js
@@ -943,9 +943,13 @@ exports.typeset = function (data, callback) {
 
 //
 //  Manually start MathJax (this is done automatically
-//  when the first typeset() call is made)
+//  when the first typeset() call is made), but don't
+//  restart if we are already starting up (prevents
+//  multiple calls to start() from causing confusion).
 //
-exports.start = function () {RestartMathJax()}
+exports.start = function () {
+  if (serverState !== STATE.STARTED) RestartMathJax();
+}
 
 //
 //  Configure MathJax and the API

--- a/test/base-config-fonturl.js
+++ b/test/base-config-fonturl.js
@@ -6,27 +6,41 @@ tape('basic configuration: check fontURL', function (t) {
     t.plan(2);
 
     var tex = 'a';
-    mjAPI.typeset({
-        math: tex,
-        format: "TeX",
-        css: true
-    }, function (result, data) {
-        t.ok(result.css.indexOf('https://cdnjs.cloudflare.com/ajax/libs/mathjax/' + mjVersion + '/fonts/HTML-CSS') > -1, 'Default fontURL');
-    });
-    // reconfigure
-    mjAPI.typeset({
-        math: ''
-    }, function () {
-        mjAPI.config({
-            fontURL: 'https://example.com'
-        });
-        mjAPI.start();
-    })
+
     mjAPI.typeset({
         math: tex,
         format: "TeX",
         css: true,
+        htmlNode: true
     }, function (result, data) {
-        t.ok(result.css.indexOf('https://example.com') > -1, 'Configuring fontURL');
+        var mjVersion = result.htmlNode.ownerDocument.defaultView.MathJax.version;
+        var URL = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' + mjVersion + '/fonts/HTML-CSS';
+        t.ok(result.css.indexOf(URL) > -1, 'Default fontURL');
+
+        //
+        // reconfigure
+        //
+        mjAPI.config({
+            fontURL: 'https://example.com'
+        });
+        mjAPI.start();
+
+        //
+        // Next test
+        //
+
+        mjAPI.typeset({
+            math: 'a',
+            format: "TeX",
+            css: true,
+        }, function (result, data) {
+            t.ok(result.css.indexOf('https://example.com') > -1, 'Configuring fontURL');
+            //
+            // reconfigure
+            //
+            mjAPI.config({fontURL: ''});
+            mjAPI.start();
+        });
+
     });
 });

--- a/test/base-mathjax.js
+++ b/test/base-mathjax.js
@@ -2,17 +2,17 @@ var tape = require('tape');
 var mjAPI = require("../lib/main.js");
 
 tape('basic test: check MathJax core', function(t) {
-  t.plan(2);
+    t.plan(2);
 
-  var tex = '';
-  mjAPI.start();
+    var tex = '';
 
-  mjAPI.typeset({
-    math: tex,
-    format: "TeX",
-    mml: true
-  }, function(result,data) {
-    t.ok(result.mml, 'MathJax core seems ok');
-    t.ok(data.format, 'MathJax input preserved');
-  });
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        mml: true
+    }, function(result,data) {
+        t.ok(result.mml, 'MathJax core seems ok');
+        t.ok(data.format, 'MathJax input preserved');
+    });
+
 });

--- a/test/base-typeset-promise.js
+++ b/test/base-typeset-promise.js
@@ -4,20 +4,33 @@ var mjAPI = require("../lib/main.js");
 tape('basic test: check typeset promise API', function (t) {
     t.plan(2);
 
-    var tex = '';
     mjAPI.config({displayErrors: false});
-    mjAPI.start();
 
+    var tex = '';
+
+    //
     // promise resolved
+    //
     mjAPI.typeset({
         math: tex,
         format: "TeX",
         mml: true
     }).then((result) => t.ok(result.mml, 'Typset promise resolved on success'));
 
+    //
+    // promise frejected
+    //
     mjAPI.typeset({
         math: tex,
         format: "MathML",
         mml: true
     }).catch((error) => t.ok(error, 'Typeset promise rejected on error'));
+
+    //
+    // reset configuration
+    //
+    mjAPI.typeset({math: '', format: 'TeX', mml: true}, () => {
+        mjAPI.config({displayErrors: true});
+    });
+
 });

--- a/test/base-warnings.js
+++ b/test/base-warnings.js
@@ -4,9 +4,19 @@ mjAPI.config({undefinedCharError: true});
 
 tape('basic test: check warnings', function (t) {
     t.plan(2);
+
     mjAPI.config({displayErrors: false});
+
     mjAPI.typeset({math:'\u5475', html:true})
         .catch(errors => t.ok(errors, 'CommonHTML output reports error'));
     mjAPI.typeset({math:'\u5475', svg:true})
         .catch(errors => t.ok(errors, 'SVG output reports error'));
+
+    //
+    // reset configuration
+    //
+    mjAPI.typeset({math: '', format: 'TeX', mml: true}, () => {
+        mjAPI.config({displayErrors: true});
+    });
+
 });

--- a/test/config-third-party-extensions.js
+++ b/test/config-third-party-extensions.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 tape('Configuring third party extensions', function(t) {
     t.plan(1);
-    var tex = '\\test';
+
     mjAPI.config( {
         extensions: '[test]/test.js',
         paths: {
@@ -12,11 +12,20 @@ tape('Configuring third party extensions', function(t) {
         }
     });
     mjAPI.start();
+
+    var tex = '\\test';
+
     mjAPI.typeset({
         math: tex,
         format: "TeX",
         mmlNode: true
     }, function(data) {
         t.notOk(data.errors, 'No error loading the extension');
+        //
+        // reset configuration
+        //
+        mjAPI.config({extensions: '', paths: {}});
+        mjAPI.start();
     });
+
 });

--- a/test/css.js
+++ b/test/css.js
@@ -3,8 +3,7 @@ var mjAPI = require("../lib/main.js");
 
 tape('CSS output', function(t) {
     t.plan(3);
-    mjAPI.start();
-    var tex = 'x';
+
     mjAPI.typeset({
         math: tex,
         format: "TeX",
@@ -12,6 +11,9 @@ tape('CSS output', function(t) {
     }, function(data) {
         t.ok(data.css, 'css output while no other output');
     });
+
+    var tex = 'x';
+
     mjAPI.typeset({
         math: tex,
         format: "TeX",
@@ -21,4 +23,5 @@ tape('CSS output', function(t) {
         t.ok(data.css, 'css output created alongside SVG output');
         t.ok(data.svg, 'svg output is created');
     });
+
 });

--- a/test/issue104.js
+++ b/test/issue104.js
@@ -5,7 +5,6 @@ var JSDOM = require('jsdom').JSDOM;
 tape('the SVG width should match the default', function(t) {
   t.plan(1);
 
-  mjAPI.start();
   var tex = 'a \\\\ b';
   var expected = '100ex';
 
@@ -20,4 +19,5 @@ tape('the SVG width should match the default', function(t) {
     var width = element.getAttribute('width');
     t.equal(width, expected);
   });
+
 });

--- a/test/issue175.js
+++ b/test/issue175.js
@@ -3,27 +3,31 @@ var mjAPI = require("../lib/main.js");
 var JSDOM = require('jsdom').JSDOM;
 
 tape('color extension should be reset', function(t) {
-  t.plan(3);
-  mjAPI.config({displayErrors: false});
-  mjAPI.start();
-  var tex = '\\colorbox{green}{x}';
-  var tex2 = '\\color{red}{x}x';
+    t.plan(3);
 
-  mjAPI.typeset({
-    math: tex,
-    format: "TeX",
-     mml: true
-  }, function(data) {
-    t.ok(data.errors, 'Color extension disabled');
-  });
-  mjAPI.typeset({
-    math: tex2,
-    format: "TeX",
-     mml: true
-  }, function(data) {
-    var document = new JSDOM(data.mml).window.document;
-    var mstyle = document.querySelector('mstyle');
-    t.ok(document.querySelectorAll('mi')[0].parentNode === mstyle, 'Color macro behaves correctly (1 of 2)');
-    t.notOk(document.querySelectorAll('mi')[1].parentNode === mstyle, 'Color macro behaves correctly (2 of 2)');
-  });
+    mjAPI.config({displayErrors: false});
+
+    var tex = '\\colorbox{green}{x}';
+    var tex2 = '\\color{red}{x}x';
+
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        mml: true
+    }, function(data) {
+        t.ok(data.errors, 'Color extension disabled');
+    });
+
+    mjAPI.typeset({
+        math: tex2,
+        format: "TeX",
+        mml: true
+    }, function(data) {
+        var document = new JSDOM(data.mml).window.document;
+        var mstyle = document.querySelector('mstyle');
+        t.ok(document.querySelectorAll('mi')[0].parentNode === mstyle, 'Color macro behaves correctly (1 of 2)');
+        t.notOk(document.querySelectorAll('mi')[1].parentNode === mstyle, 'Color macro behaves correctly (2 of 2)');
+        mjAPI.config({displayErrors: true});  // reset configuration
+    });
+
 });

--- a/test/issue207.js
+++ b/test/issue207.js
@@ -3,55 +3,64 @@ var mjAPI = require("../lib/main.js");
 var JSDOM = require('jsdom').JSDOM;
 
 tape('Generate dummy speechText', function(t) {
-  t.plan(9);
-  mjAPI.start();
-  var input1 = 'source';
-  var input2 = '<math display="block" alttext="alttext"><mi>x</mi></math>';
-  var input3 = '<math display="block"><mi>x</mi></math>';
-  var expected1 = 'source';
-  var expected2 = 'alttext';
-  var expected3 = 'Equation';
-  var desc1 = 'source';
-  var desc2 = 'original MathML alttext';
-  var desc3 = 'default dummy value';
+    t.plan(9);
 
-  mjSpeechTest = function(data, expected, desc) {
-    var document = new JSDOM(data.html).window.document;
-    var element = document.querySelector('.mjx-math');
-    var actual = element.getAttribute('aria-label');
-    t.equal(actual, expected, 'HTML output contains speechText from ' + desc);
-    document = new JSDOM(data.mml).window.document;
-    element = document.querySelector('math');
-    actual = element.getAttribute('alttext');
-    t.equal(actual, expected, 'MathML output contains speechText from ' + desc);
-    document = new JSDOM(data.svg).window.document;
-    var svgTitle = document.querySelector('title');
-    actual = svgTitle.innerHTML;
-    t.equal(actual, expected, 'SVG output contains speechText from ' + desc);
-  };
+    var input1 = 'source';
+    var input2 = '<math display="block" alttext="alttext"><mi>x</mi></math>';
+    var input3 = '<math display="block"><mi>x</mi></math>';
+    var expected1 = 'source';
+    var expected2 = 'alttext';
+    var expected3 = 'Equation';
+    var desc1 = 'source';
+    var desc2 = 'original MathML alttext';
+    var desc3 = 'default dummy value';
 
-  // TeX source
-  mjAPI.typeset({
-    math: input1,
-    format: "TeX",
-    html: true,
-    svg: true,
-    mml: true
-  }, function(data) {mjSpeechTest(data, expected1, desc1)});
-  // MathML alttext
-  mjAPI.typeset({
-    math: input2,
-    format: "MathML",
-    html: true,
-    svg: true,
-    mml: true
-  }, function(data) {mjSpeechTest(data, expected2, desc2)});
-  // MathML without alttext
-  mjAPI.typeset({
-    math: input3,
-    format: "MathML",
-    html: true,
-    svg: true,
-    mml: true
-  }, function(data) {mjSpeechTest(data, expected3, desc3)});
+    mjSpeechTest = function(data, expected, desc) {
+        var document = new JSDOM(data.html).window.document;
+        var element = document.querySelector('.mjx-math');
+        var actual = element.getAttribute('aria-label');
+        t.equal(actual, expected, 'HTML output contains speechText from ' + desc);
+        document = new JSDOM(data.mml).window.document;
+        element = document.querySelector('math');
+        actual = element.getAttribute('alttext');
+        t.equal(actual, expected, 'MathML output contains speechText from ' + desc);
+        document = new JSDOM(data.svg).window.document;
+        var svgTitle = document.querySelector('title');
+        actual = svgTitle.innerHTML;
+        t.equal(actual, expected, 'SVG output contains speechText from ' + desc);
+    };
+
+    //
+    // TeX source
+    //
+    mjAPI.typeset({
+        math: input1,
+        format: "TeX",
+        html: true,
+        svg: true,
+        mml: true
+    }, function(data) {mjSpeechTest(data, expected1, desc1)});
+
+    //
+    // MathML alttext
+    //
+    mjAPI.typeset({
+        math: input2,
+        format: "MathML",
+        html: true,
+        svg: true,
+        mml: true
+    }, function(data) {mjSpeechTest(data, expected2, desc2)});
+
+    //
+    // MathML without alttext
+    //
+    mjAPI.typeset({
+        math: input3,
+        format: "MathML",
+        html: true,
+        svg: true,
+        mml: true
+    }, function(data) {mjSpeechTest(data, expected3, desc3)});
+
 });

--- a/test/issue215.js
+++ b/test/issue215.js
@@ -3,21 +3,21 @@ var mjAPI = require("../lib/main.js");
 var JSDOM = require('jsdom').JSDOM;
 
 tape('HTML output should remove automatically generated IDs', function(t) {
-  t.plan(2);
+    t.plan(2);
 
-  mjAPI.start();
-  var tex = 'a \\\\ b';
-  var expected = '100ex';
+    var tex = 'a \\\\ b';
+    var expected = '100ex';
 
-  mjAPI.typeset({
-    math: tex,
-    format: "TeX",
-    html: true
-  }, function(data) {
-    var document = new JSDOM(data.html).window.document;
-    var id = document.querySelector('[id^="MJXc-Node-"]');
-    var frame = document.querySelector('[id^="MathJax-Element-"]');
-    t.notOk(id, 'automatic ids successfully removed');
-    t.notOk(frame, 'MathJax-Element-[n]-frame id successfully removed');
-  });
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        html: true
+    }, function(data) {
+        var document = new JSDOM(data.html).window.document;
+        var id = document.querySelector('[id^="MJXc-Node-"]');
+        var frame = document.querySelector('[id^="MathJax-Element-"]');
+        t.notOk(id, 'automatic ids successfully removed');
+        t.notOk(frame, 'MathJax-Element-[n]-frame id successfully removed');
+    });
+
 });

--- a/test/issue219.js
+++ b/test/issue219.js
@@ -3,24 +3,24 @@ var mjAPI = require("../lib/main.js");
 var JSDOM = require('jsdom').JSDOM;
 
 tape('Basic Check: pass jsdom object to output', function(t) {
-  t.plan(3);
+    t.plan(3);
 
-  mjAPI.start();
-  var tex = 'x';
+    var tex = 'x';
 
-  mjAPI.typeset({
-    math: tex,
-    format: "TeX",
-    html: true,
-    htmlNode: true,
-    svg: true,
-    svgNode: true,
-    mml: true,
-    mmlNode: true
-  }, function(data) {
-    var window = new JSDOM().window;
-    t.ok(data.htmlNode instanceof window.HTMLElement, 'htmlNode is an HTMLElement');
-    t.ok(data.svgNode instanceof window.SVGElement, 'svgNode is an SVGElement');
-    t.ok(data.mmlNode instanceof window.Element, 'mmlNode is an Element');
-  });
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        html: true,
+        htmlNode: true,
+        svg: true,
+        svgNode: true,
+        mml: true,
+        mmlNode: true
+    }, function(data) {
+        var window = new JSDOM().window;
+        t.ok(data.htmlNode instanceof window.HTMLElement, 'htmlNode is an HTMLElement');
+        t.ok(data.svgNode instanceof window.SVGElement, 'svgNode is an SVGElement');
+        t.ok(data.mmlNode instanceof window.Element, 'mmlNode is an Element');
+    });
+
 });

--- a/test/issue220.js
+++ b/test/issue220.js
@@ -3,20 +3,28 @@ var mjAPI = require("../lib/main.js");
 var JSDOM = require('jsdom').JSDOM;
 
 tape('displayAlign:left in HTML output', function(t) {
-  t.plan(1);
-  mjAPI.config({MathJax: {"displayAlign": "left"}});
-  mjAPI.start();
-  var tex = 'x';
-  var expected = "text-align: left;";
+    t.plan(1);
 
-  mjAPI.typeset({
-    math: tex,
-    format: "TeX",
-    html: true
-  }, function(data) {
-    var document = new JSDOM(data.html).window.document;
-    var element = document.getElementsByClassName("MJXc-display")[0];
-    var result = element.getAttribute('style');
-    t.equal(result, expected);
-  });
+    mjAPI.config({MathJax: {"displayAlign": "left"}});
+    mjAPI.start();
+
+    var tex = 'x';
+    var expected = "text-align: left;";
+
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        html: true
+    }, function(data) {
+        var document = new JSDOM(data.html).window.document;
+        var element = document.getElementsByClassName("MJXc-display")[0];
+        var result = element.getAttribute('style');
+        t.equal(result, expected);
+        //
+        // reset configuration
+        //
+        mjAPI.config({MathJax: {}});
+        mjAPI.start();
+    });
+
 });

--- a/test/issue223.js
+++ b/test/issue223.js
@@ -3,40 +3,46 @@ var mjAPI = require("../lib/main.js");
 var JSDOM = require('jsdom').JSDOM;
 
 tape('displayIndent:left in HTML output', function(t) {
-  t.plan(2);
-  mjAPI.config({MathJax: {displayIndent: '10em'}});
-  mjAPI.start();
-  var first = 'x';
-  var second = 'x \\tag{1}'
-  expected = "10em";
+    t.plan(2);
 
-  // basic text
-  mjAPI.typeset({
-    math: first,
-    format: "TeX",
-    html: true
-  }, function(data) {
-    var document = new JSDOM(data.html).window.document;
-    var element = document.getElementsByClassName('MJXc-display')[0];
-    var result = element.style.marginLeft;
-    t.ok((result === expected), 'style includes a margin');
-  });
+    mjAPI.config({MathJax: {displayIndent: '10em'}});
+    mjAPI.start();
+    
+    var first = 'x';
+    var second = 'x \\tag{1}'
+    expected = "10em";
 
-  // test for mlabeledtr
-  mjAPI.typeset({
-    math: second,
-    format: "TeX",
-    html: true
-  }, function(data) {
-    var document = new JSDOM(data.html).window.document;
-    var element = document.getElementsByClassName('mjx-table')[0];
-    var result = element.style.marginLeft;
-    t.ok((result === expected), 'style includes a margin');
-  });
-   // reset configuration
+    //
+    // basic text
+    //  
     mjAPI.typeset({
-        math: ''
-    }, function(){
-        mjAPI.config({MathJax: {displayIndent: '0em'}});
-    })
+        math: first,
+        format: "TeX",
+        html: true
+    }, function(data) {
+        var document = new JSDOM(data.html).window.document;
+        var element = document.getElementsByClassName('MJXc-display')[0];
+        var result = element.style.marginLeft;
+        t.ok((result === expected), 'style includes a margin');
+    });
+
+    //
+    // test for mlabeledtr
+    //
+    mjAPI.typeset({
+        math: second,
+        format: "TeX",
+        html: true
+    }, function(data) {
+        var document = new JSDOM(data.html).window.document;
+        var element = document.getElementsByClassName('mjx-table')[0];
+        var result = element.style.marginLeft;
+        t.ok((result === expected), 'style includes a margin');
+        //
+        // reset configuration
+        //
+        mjAPI.config({MathJax: {}});
+        mjAPI.start();
+    });
+
 });

--- a/test/issue241.js
+++ b/test/issue241.js
@@ -2,16 +2,17 @@ var tape = require('tape');
 var mjAPI = require("../lib/main.js");
 
 tape('SVG output: add xlink to href in <image>', function(t) {
-  t.plan(1);
-  mjAPI.start();
-  var mml = '<math><mglyph src="equation.svg" width="319pt" height="14pt"></mglyph></math>';
-  var expected = /xlink:href/;
+    t.plan(1);
 
-  mjAPI.typeset({
-    math: mml,
-    format: "MathML",
-    svg: true
-  }, function(data) {
-    t.ok(data.svg.match(expected));
-  });
+    var mml = '<math><mglyph src="equation.svg" width="319pt" height="14pt"></mglyph></math>';
+    var expected = /xlink:href/;
+
+    mjAPI.typeset({
+        math: mml,
+        format: "MathML",
+        svg: true
+    }, function(data) {
+        t.ok(data.svg.match(expected));
+    });
+
 });

--- a/test/issue260.js
+++ b/test/issue260.js
@@ -2,24 +2,25 @@ var tape = require('tape');
 var mjAPI = require('../lib/main.js');
 
 tape('getSVG should increment state.ID', function(t) {
-  t.plan(1);
+    t.plan(1);
 
-  mjAPI.start();
-  var mml = '<math><mn>1</mn></math>';
-  var state = {};
-  mjAPI.typeset({
-    math: mml,
-    format: 'MathML',
-    speakText: true,
-    svg: true,
-    state: state}, function(data) {});
-  mjAPI.typeset({
-    math: mml,
-    format: 'MathML',
-    speakText: true,
-    svg: true,
-    state: state
-  }, function(data) {
-    t.equal(state.ID, 2, 'state.ID incremented')
-  });
+    var mml = '<math><mn>1</mn></math>';
+    var state = {};
+
+    mjAPI.typeset({
+        math: mml,
+        format: 'MathML',
+        speakText: true,
+        svg: true,
+        state: state}, function(data) {});
+    mjAPI.typeset({
+        math: mml,
+        format: 'MathML',
+        speakText: true,
+        svg: true,
+        state: state
+    }, function(data) {
+        t.equal(state.ID, 2, 'state.ID incremented')
+    });
+
 });

--- a/test/issue276.js
+++ b/test/issue276.js
@@ -3,17 +3,18 @@ var mjAPI = require("../lib/main.js");
 var JSDOM = require('jsdom').JSDOM;
 
 tape('SVG output: physical units', function(t) {
-  t.plan(1);
-  mjAPI.start();
-  var mml = '<math><mspace width="1cm"></mspace></math>';
+    t.plan(1);
 
-  mjAPI.typeset({
-    math: mml,
-    format: "MathML",
-    svg: true
-  }, function(data) {
-    var document = new JSDOM(data.svg).window.document;
-    var width =  document.querySelector('svg').getAttribute('width');
-    t.notEqual(width, '0', '');
-  });
+    var mml = '<math><mspace width="1cm"></mspace></math>';
+
+    mjAPI.typeset({
+        math: mml,
+        format: "MathML",
+        svg: true
+    }, function(data) {
+        var document = new JSDOM(data.svg).window.document;
+        var width =  document.querySelector('svg').getAttribute('width');
+        t.notEqual(width, '0', '');
+    });
+
 });

--- a/test/issue277.js
+++ b/test/issue277.js
@@ -3,7 +3,7 @@ var mjAPI = require("../lib/main.js");
 
 tape('mmlNode should not produce mml', function(t) {
     t.plan(1);
-    mjAPI.start();
+
     var tex = 'x';
 
     mjAPI.typeset({
@@ -13,4 +13,5 @@ tape('mmlNode should not produce mml', function(t) {
     }, function(data) {
         t.ok(data.mml === undefined, 'mml not generated');
     });
+
 });

--- a/test/issue288.js
+++ b/test/issue288.js
@@ -3,7 +3,7 @@ var mjAPI = require("../lib/main.js");
 
 tape('HTML output when requesting both SVG and HTML', function(t) {
     t.plan(2);
-    mjAPI.start();
+
     var tex = 'x';
 
     mjAPI.typeset({
@@ -23,4 +23,5 @@ tape('HTML output when requesting both SVG and HTML', function(t) {
     }, function(data) {
         t.ok(data.html, 'html output is present')
     });
+
 });

--- a/test/issue289.js
+++ b/test/issue289.js
@@ -3,7 +3,7 @@ var mjAPI = require("../lib/main.js");
 
 tape('HTML output: add aria-label to correct childnode', function(t) {
     t.plan(1);
-    mjAPI.start();
+
     var mml = '<math alttext="0"><mn>1</mn></math>';
 
     mjAPI.typeset({
@@ -14,4 +14,5 @@ tape('HTML output: add aria-label to correct childnode', function(t) {
     }, function(data) {
         t.equal(data.htmlNode.parentNode.querySelectorAll('[aria-label]').length, 1, 'Aria-label is unique');
     });
+
 });

--- a/test/mathjax-config-combined.js
+++ b/test/mathjax-config-combined.js
@@ -3,17 +3,25 @@ var mjAPI = require("../lib/main.js");
 
 tape('MathJax configuration: strip config block', function (t) {
     t.plan(1);
+
     mjAPI.config({
         MathJax: {
             config: ["TeX-AMS_SVG.js"]
         }
     });
+    mjAPI.start();
+
     mjAPI.typeset({
         math: 'E = mc^2',
         format: "TeX",
         mml: true,
     }, function (data) {
         t.ok(data, 'Config block did not cause errors');
+        //
+        // reset configuration
+        //
+        mjAPI.config({MathJax: {}});
+        mjAPI.start();
     });
 
 });

--- a/test/output-html-linebreaks-manual.js
+++ b/test/output-html-linebreaks-manual.js
@@ -2,15 +2,17 @@ var tape = require('tape');
 var mjAPI = require("../lib/main.js");
 
 tape('Output, HTML: linebreaks, manual', function(t) {
-  t.plan(1);
-  mjAPI.start();
-  var tex = 'A \\\\ B';
-  var expected = '<span class="mjx-chtml MJXc-display"><span class="mjx-math" style="width: 100%;" aria-label="A \\\\ B"><span class="mjx-mrow" style="width: 100%;" aria-hidden="true"><span class="mjx-stack" style="width: 100%; vertical-align: -1.2em;"><span class="mjx-block" style="text-align: center;"><span class="mjx-box"><span class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.298em;">A</span></span></span></span><span class="mjx-block" style="text-align: center; padding-top: 0.467em;"><span class="mjx-box"><span class="mjx-mspace" style="width: 0px; height: 0px;"></span><span class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">B</span></span></span></span></span></span></span></span>'
-  mjAPI.typeset({
-    math: tex,
-    format: "TeX",
-    html: true
-  }, function(data) {
-    t.equal(data.html, expected, 'HTML output as expected');
-  });
+    t.plan(1);
+
+    var tex = 'A \\\\ B';
+    var expected = '<span class="mjx-chtml MJXc-display"><span class="mjx-math" style="width: 100%;" aria-label="A \\\\ B"><span class="mjx-mrow" style="width: 100%;" aria-hidden="true"><span class="mjx-stack" style="width: 100%; vertical-align: -1.2em;"><span class="mjx-block" style="text-align: center;"><span class="mjx-box"><span class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.298em;">A</span></span></span></span><span class="mjx-block" style="text-align: center; padding-top: 0.467em;"><span class="mjx-box"><span class="mjx-mspace" style="width: 0px; height: 0px;"></span><span class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">B</span></span></span></span></span></span></span></span>'
+
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        html: true
+    }, function(data) {
+        t.equal(data.html, expected, 'HTML output as expected');
+    });
+
 });

--- a/test/pass_data.js
+++ b/test/pass_data.js
@@ -3,8 +3,9 @@ var mjAPI = require("../lib/main.js");
 
 tape('Passing data along', function(t) {
     t.plan(1);
-    mjAPI.start();
+
     var tex = 'x';
+
     mjAPI.typeset({
         math: tex,
         format: "TeX",
@@ -13,4 +14,5 @@ tape('Passing data along', function(t) {
     }, function(data, input) {
         t.equal(input.something, 'expected', 'Data was passed along to output');
     });
+
 });

--- a/test/svg-full-width-chars.js
+++ b/test/svg-full-width-chars.js
@@ -2,17 +2,19 @@ var tape = require('tape');
 var mjAPI = require("../lib/main.js");
 
 tape('the SVG output should renders full-width characters correctly', function(t) {
-  t.plan(1);
+    t.plan(1);
 
-  mjAPI.config({displayErrors: false});
-  mjAPI.start();
-  var tex = '\\text{\u62FE\u96F6}^i';
+    mjAPI.config({displayErrors: false});
 
-  mjAPI.typeset({
-    math: tex,
-    format: "TeX",
-    svg: true
-  }, function(data) {
-    t.ok(data.width, '5.133ex', 'Width is correct');
-  });
+    var tex = '\\text{\u62FE\u96F6}^i';
+
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        svg: true
+    }, function(data) {
+        t.ok(data.width, '5.133ex', 'Width is correct');
+        mjAPI.config({displayErrors: true});  // reset configuration
+    });
+
 });

--- a/test/svg-metadata.js
+++ b/test/svg-metadata.js
@@ -3,18 +3,18 @@ var mjAPI = require("../lib/main.js");
 var jsdom = require('jsdom').jsdom;
 
 tape('the SVG output should add dimensions and styles', function(t) {
-  t.plan(3);
+    t.plan(3);
 
-  mjAPI.start();
-  var tex = 'a + b';
+    var tex = 'a + b';
 
-  mjAPI.typeset({
-    math: tex,
-    format: "TeX",
-    svg: true
-  }, function(data) {
-    t.ok(data.width, 'Width is present');
-    t.ok(data.height, 'Height is present');
-    t.ok(data.style, 'Style is present');
-  });
+    mjAPI.typeset({
+        math: tex,
+        format: "TeX",
+        svg: true
+    }, function(data) {
+        t.ok(data.width, 'Width is present');
+        t.ok(data.height, 'Height is present');
+        t.ok(data.style, 'Style is present');
+    });
+
 });

--- a/test/useFontCache.js
+++ b/test/useFontCache.js
@@ -5,6 +5,7 @@ tape('basic configuration: useFontCache', function (t) {
     t.plan(2);
 
     var tex = 'a';
+
     mjAPI.typeset({
         math: tex,
         format: "TeX",
@@ -13,6 +14,7 @@ tape('basic configuration: useFontCache', function (t) {
     }, function (result, data) {
         t.ok(result.svg.indexOf('<use') === -1, 'useFontCache set to false');
     });
+
     mjAPI.typeset({
         math: tex,
         format: "TeX",
@@ -21,4 +23,5 @@ tape('basic configuration: useFontCache', function (t) {
     }, function (result, data) {
         t.ok(result.svg.indexOf('<use') >  -1, 'useFontCache set to true');
     });
+
 });

--- a/test/userconfig-autoload.js
+++ b/test/userconfig-autoload.js
@@ -4,11 +4,12 @@ var mjAPI = require("../lib/main.js");
 tape('User config: autoload-all should enable color extension', function(t) {
     t.plan(1);
 
-    var tex = '\\definecolor{myorange}{RGB}{255,165,100}\\color{myorange}e^{i \\pi}\\color{Black} = -1';
     mjAPI.config( {
         extensions: 'TeX/autoload-all', // a convenience option to add MathJax extensions
     });
     mjAPI.start();
+
+    var tex = '\\definecolor{myorange}{RGB}{255,165,100}\\color{myorange}e^{i \\pi}\\color{Black} = -1';
 
     mjAPI.typeset({
         math: tex,
@@ -16,5 +17,11 @@ tape('User config: autoload-all should enable color extension', function(t) {
         mml: true
     }, function(data) {
         t.ok(!data.errors, 'definecolor should be a known function');
+        //
+        // reset configuration
+        //
+        mjAPI.config({extenstion: ''});
+        mjAPI.start();
     });
+
 });

--- a/test/userconfig-jax.js
+++ b/test/userconfig-jax.js
@@ -2,18 +2,26 @@ var tape = require('tape');
 var mjAPI = require('../lib/main.js');
 
 tape('User configuration with jax array', function (t) {
-        t.plan(1);
+    t.plan(1);
 
-        mjAPI.config({
-                MathJax: {
-                        jax: ["input/MathML", "output/SVG"]
-                }
-        });
-        mjAPI.typeset({
-                math: '<math><mn>1</mn></math>',
-                format: 'MathML',
-                svg: true
-        }, function (data) {
-                t.ok(!data.errors, 'No errors');
-        });
+    mjAPI.config({
+        MathJax: {
+            jax: ["input/MathML", "output/SVG"]
+        }
+    });
+    mjAPI.start();
+
+    mjAPI.typeset({
+        math: '<math><mn>1</mn></math>',
+        format: 'MathML',
+        svg: true
+    }, function (data) {
+        t.ok(!data.errors, 'No errors');
+        //
+        // reset configuration
+        //
+        mjAPI.config({MathJax: {}});
+        mjAPI.start();
+    });
+
 });


### PR DESCRIPTION
If `start()` was called while MathJax was starting up from a previous `start()` or `typeset()` call, this could cause crashes (and did cause crashes for some tape tests). 

This PR fixes `start()` so that it delays the restart until the previous MathJax has started up.

It also removes unneeded `start()` calls from the test files (no need to create a new window and reload MathJax unnecessarily), and adds configuration resets for those tests that include configuration changes.  Finally, it normalizes the format of the tests.