### PR TITLE
Fix extensions parsing removing trailing 's' chars

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -528,7 +528,7 @@ function ConfigureMathJax() {
     //
     // Parse added extensions list and add to standard ones
     //
-    var extensionList = extensions.split(/s*,\s*/);
+    var extensionList = extensions.split(/\s*,\s*/);
     for (var i = 0; i < extensionList.length; i++) {
       var matches = extensionList[i].match(/^(.*?)(\.js)?$/);
       window.MathJax.extensions.push(matches[1] + '.js');


### PR DESCRIPTION
The regular expression for parsing the MathJaX configuration `extensions`  setting accidentally, as far as I can tell, removed any trailing 's' of any but the last item -- instead of removing trailing spaces, which seems to have been the intention.